### PR TITLE
Refunding order shipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
     - composer validate --strict
     - bin/phpstan.phar analyse -c phpstan.neon -l max src/
 
-    - bin/behat features/
+    - bin/behat -vvv --no-interaction || bin/behat -vvv --no-interaction --rerun
 
 after_failure:
     - vendor/lakion/mink-debug-extension/travis/tools/upload-textfiles "${SYLIUS_BUILD_DIR}/*.log"

--- a/features/refunding_all_order_units.feature
+++ b/features/refunding_all_order_units.feature
@@ -7,7 +7,7 @@ Feature: Refunding all order units
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
-        And the store allows shipping with "Galaxy Post"
+        And the store has "Galaxy Post" shipping method with "$10.00" fee
         And the store allows paying with "Space money"
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
         And the customer bought 3 "Mr. Meeseeks T-Shirt" products
@@ -20,7 +20,8 @@ Feature: Refunding all order units
         When I want to refund some units of order "#00000022"
         And I decide to refund all units of this order
         Then I should be notified that selected order units have been successfully refunded
-        And this order refunded total should be "$30.00"
-        And I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"
-        But I should not be able to refund 2nd unit with product "Mr. Meeseeks T-Shirt"
-        But I should not be able to refund 3rd unit with product "Mr. Meeseeks T-Shirt"
+        And this order refunded total should be "$40.00"
+        But I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"
+        And I should not be able to refund 2nd unit with product "Mr. Meeseeks T-Shirt"
+        And I should not be able to refund 3rd unit with product "Mr. Meeseeks T-Shirt"
+        And I should not be able to refund order shipment

--- a/features/refunding_all_order_units.feature
+++ b/features/refunding_all_order_units.feature
@@ -6,7 +6,7 @@ Feature: Refunding all order units
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
         And the store allows shipping with "Galaxy Post"
         And the store allows paying with "Space money"
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -12,6 +12,7 @@ Feature: Refunding an order shipping cost
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
         And the customer bought 2 "Mr. Meeseeks T-Shirt" products
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And the order "#00000022" is already paid
         And I am logged in as an administrator
 
     @ui @application

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -1,0 +1,33 @@
+@refunds
+Feature: Refunding an order shipping cost
+    In order to give back money spent by Customer for order shipment
+    As an Administrator
+    I want to be able to refund an order shipping cost
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
+        And the store has "Galaxy Post" shipping method with "$20.00" fee
+        And the store allows paying with "Space money"
+        And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
+        And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And I am logged in as an administrator
+
+    @ui @application
+    Scenario: Refunding an order shipment
+        When I want to refund some units of order "#00000022"
+        And I decide to refund order shipment
+        Then I should be notified that order shipment has been successfully refunded
+        And this order refunded total should be "$20.00"
+        And I should not be able to refund order shipment
+
+    @ui @application
+    Scenario: Refunding and order shipment along with order unit
+        When I want to refund some units of order "#00000022"
+        And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product
+        Then I should be notified that order shippment has been successfully refunded
+        Then I should be notified that selected order units have been successfully refunded
+        And this order refunded total should be "$30.00"
+        And I should not be able to refund order shipment
+        And I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -18,7 +18,6 @@ Feature: Refunding an order shipping cost
     Scenario: Refunding an order shipment
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment
-        Then I should be notified that order shipment has been successfully refunded
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
@@ -26,7 +25,6 @@ Feature: Refunding an order shipping cost
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product
-        Then I should be notified that order shipment has been successfully refunded
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$30.00"
         And I should not be able to refund order shipment

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -22,7 +22,7 @@ Feature: Refunding an order shipping cost
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
-    @application
+    @application @todo
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -14,7 +14,7 @@ Feature: Refunding an order shipping cost
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And I am logged in as an administrator
 
-    @ui @application
+    @application
     Scenario: Refunding an order shipment
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment
@@ -22,11 +22,11 @@ Feature: Refunding an order shipping cost
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
-    @ui @application
+    @application
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product
-        Then I should be notified that order shippment has been successfully refunded
+        Then I should be notified that order shipment has been successfully refunded
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$30.00"
         And I should not be able to refund order shipment

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -22,7 +22,7 @@ Feature: Refunding an order shipping cost
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
-    @application @todo
+    @application
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -14,7 +14,7 @@ Feature: Refunding an order shipping cost
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And I am logged in as an administrator
 
-    @application
+    @ui @application
     Scenario: Refunding an order shipment
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment
@@ -22,7 +22,7 @@ Feature: Refunding an order shipping cost
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
-    @application
+    @ui @application
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
         And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product

--- a/features/refunding_single_order_unit.feature
+++ b/features/refunding_single_order_unit.feature
@@ -6,7 +6,7 @@ Feature: Refunding a single order unit
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
         And the store allows shipping with "Galaxy Post"
         And the store allows paying with "Space money"
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"

--- a/features/refunding_single_order_unit_with_promotion_applied.feature
+++ b/features/refunding_single_order_unit_with_promotion_applied.feature
@@ -6,7 +6,7 @@ Feature: Refunding a single order unit with promotion applied
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
         And the store allows shipping with "Galaxy Post"
         And the store allows paying with "Space money"
         And there is a promotion "Anatomy Park Promotion"

--- a/features/refunding_single_order_unit_with_taxes_applied.feature
+++ b/features/refunding_single_order_unit_with_taxes_applied.feature
@@ -8,7 +8,7 @@ Feature: Refunding a single order unit with taxes applied
         Given the store operates on a single channel in "United States"
         And default tax zone is "US"
         And the store has "US VAT" tax rate of 10% for "Clothes" within the "US" zone
-        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
         And it belongs to "Clothes" tax category
         And the store allows shipping with "Galaxy Post"
         And the store allows paying with "Space money"

--- a/migrations/Version20180718125528.php
+++ b/migrations/Version20180718125528.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20180718125528 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_refund_refund ADD type VARCHAR(255) NOT NULL, CHANGE refundedunitid refunded_unit_id INT DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_DEF86A0EE8F826668CDE5729 ON sylius_refund_refund (refunded_unit_id, type)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_DEF86A0EE8F826668CDE5729 ON sylius_refund_refund');
+        $this->addSql('ALTER TABLE sylius_refund_refund DROP type, CHANGE refunded_unit_id refundedUnitId INT DEFAULT NULL');
+    }
+}

--- a/spec/Checker/UnitRefundingAvailabilityCheckerSpec.php
+++ b/spec/Checker/UnitRefundingAvailabilityCheckerSpec.php
@@ -8,6 +8,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class UnitRefundingAvailabilityCheckerSpec extends ObjectBehavior
 {
@@ -23,17 +24,27 @@ final class UnitRefundingAvailabilityCheckerSpec extends ObjectBehavior
 
     function it_returns_true_if_refund_for_given_unit_does_not_already_exist(RepositoryInterface $refundRepository): void
     {
-        $refundRepository->findOneBy(['refundedUnitId' => 1])->willReturn(null);
+        $refundType = RefundType::shipment();
 
-        $this->__invoke(1)->shouldReturn(true);
+        $refundRepository
+            ->findOneBy(['refundedUnitId' => 1, 'type' => $refundType->__toString()])
+            ->willReturn(null)
+        ;
+
+        $this->__invoke(1, RefundType::shipment())->shouldReturn(true);
     }
 
     function it_returns_false_if_refund_for_given_unit_does_not_already_exist(
         RepositoryInterface $refundRepository,
         RefundInterface $refund
     ): void {
-        $refundRepository->findOneBy(['refundedUnitId' => 1])->willReturn($refund);
+        $refundType = RefundType::shipment();
 
-        $this->__invoke(1)->shouldReturn(false);
+        $refundRepository
+            ->findOneBy(['refundedUnitId' => 1, 'type' => $refundType->__toString()])
+            ->willReturn($refund)
+        ;
+
+        $this->__invoke(1, $refundType)->shouldReturn(false);
     }
 }

--- a/spec/Command/RefundUnitsSpec.php
+++ b/spec/Command/RefundUnitsSpec.php
@@ -8,11 +8,12 @@ use PhpSpec\ObjectBehavior;
 
 final class RefundUnitsSpec extends ObjectBehavior
 {
-    function it_represents_an_intention_to_refund_specific_order_units(): void
+    function it_represents_an_intention_to_refund_specific_order_units_and_shipments(): void
     {
-        $this->beConstructedWith('000222', [1, 3, 5]);
+        $this->beConstructedWith('000222', [1, 3, 5], [2]);
 
         $this->orderNumber()->shouldReturn('000222');
         $this->refundedUnitIds()->shouldReturn([1, 3, 5]);
+        $this->refundedShipmentIds()->shouldReturn([2]);
     }
 }

--- a/spec/Command/RefundUnitsSpec.php
+++ b/spec/Command/RefundUnitsSpec.php
@@ -13,7 +13,7 @@ final class RefundUnitsSpec extends ObjectBehavior
         $this->beConstructedWith('000222', [1, 3, 5], [2]);
 
         $this->orderNumber()->shouldReturn('000222');
-        $this->refundedUnitIds()->shouldReturn([1, 3, 5]);
-        $this->refundedShipmentIds()->shouldReturn([2]);
+        $this->unitIds()->shouldReturn([1, 3, 5]);
+        $this->shipmentIds()->shouldReturn([2]);
     }
 }

--- a/spec/CommandHandler/RefundUnitsHandlerSpec.php
+++ b/spec/CommandHandler/RefundUnitsHandlerSpec.php
@@ -16,13 +16,13 @@ use Sylius\RefundPlugin\Refunder\RefunderInterface;
 final class RefundUnitsHandlerSpec extends ObjectBehavior
 {
     function let(
-        RefunderInterface $orderUnitsRefunder,
+        RefunderInterface $orderItemUnitsRefunder,
         RefunderInterface $orderShipmentsRefunder,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
         EventBus $eventBus
     ): void {
         $this->beConstructedWith(
-            $orderUnitsRefunder,
+            $orderItemUnitsRefunder,
             $orderShipmentsRefunder,
             $orderRefundingAvailabilityChecker,
             $eventBus
@@ -31,13 +31,13 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
 
     function it_handles_command_and_create_refund_for_each_refunded_unit(
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
-        RefunderInterface $orderUnitsRefunder,
+        RefunderInterface $orderItemUnitsRefunder,
         RefunderInterface $orderShipmentsRefunder,
         EventBus $eventBus
     ): void {
         $orderRefundingAvailabilityChecker->__invoke('000222')->willReturn(true);
 
-        $orderUnitsRefunder->refundFromOrder([1, 3], '000222')->willReturn(3000);
+        $orderItemUnitsRefunder->refundFromOrder([1, 3], '000222')->willReturn(3000);
         $orderShipmentsRefunder->refundFromOrder([3, 4], '000222')->willReturn(4000);
 
         $eventBus->dispatch(Argument::that(function (UnitsRefunded $event): bool {
@@ -46,7 +46,7 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
                 $event->unitIds() === [1, 3] &&
                 $event->shipmentIds() === [3, 4] &&
                 $event->amount() === 7000
-                ;
+            ;
         }))->shouldBeCalled();
 
         $this(new RefundUnits('000222', [1, 3], [3, 4]));

--- a/spec/Creator/RefundCreatorSpec.php
+++ b/spec/Creator/RefundCreatorSpec.php
@@ -11,6 +11,7 @@ use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
 use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundCreatorSpec extends ObjectBehavior
 {
@@ -39,12 +40,12 @@ final class RefundCreatorSpec extends ObjectBehavior
     ): void {
         $unitRefundingAvailabilityChecker->__invoke(1)->willReturn(true);
 
-        $refundFactory->createWithData('000222', 1, 1000)->willReturn($refund);
+        $refundFactory->createWithData('000222', 1, 1000, RefundType::shipment())->willReturn($refund);
 
         $refundEntityManager->persist($refund)->shouldBeCalled();
         $refundEntityManager->flush()->shouldBeCalled();
 
-        $this('000222', 1, 1000);
+        $this('000222', 1, 1000, RefundType::shipment());
     }
 
     function it_throws_exception_if_unit_has_already_been_refunded(
@@ -54,7 +55,7 @@ final class RefundCreatorSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(UnitAlreadyRefundedException::class)
-            ->during('__invoke', ['000222', 1, 1000])
+            ->during('__invoke', ['000222', 1, 1000, RefundType::orderUnit()])
         ;
     }
 }

--- a/spec/Creator/RefundCreatorSpec.php
+++ b/spec/Creator/RefundCreatorSpec.php
@@ -6,12 +6,9 @@ namespace spec\Sylius\RefundPlugin\Creator;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
-use Prooph\ServiceBus\EventBus;
-use Prophecy\Argument;
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
-use Sylius\RefundPlugin\Event\UnitRefunded;
 use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
 
@@ -20,14 +17,12 @@ final class RefundCreatorSpec extends ObjectBehavior
     function let(
         RefundFactoryInterface $refundFactory,
         UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
-        ObjectManager $refundEntityManager,
-        EventBus $eventBus
+        ObjectManager $refundEntityManager
     ): void {
         $this->beConstructedWith(
             $refundFactory,
             $unitRefundingAvailabilityChecker,
-            $refundEntityManager,
-            $eventBus
+            $refundEntityManager
         );
     }
 
@@ -40,7 +35,6 @@ final class RefundCreatorSpec extends ObjectBehavior
         RefundFactoryInterface $refundFactory,
         UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
         ObjectManager $refundEntityManager,
-        EventBus $eventBus,
         RefundInterface $refund
     ): void {
         $unitRefundingAvailabilityChecker->__invoke(1)->willReturn(true);
@@ -49,14 +43,6 @@ final class RefundCreatorSpec extends ObjectBehavior
 
         $refundEntityManager->persist($refund)->shouldBeCalled();
         $refundEntityManager->flush()->shouldBeCalled();
-
-        $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
-            return
-                $event->orderNumber() === '000222' &&
-                $event->unitId() === 1 &&
-                $event->amount() === 1000
-            ;
-        }))->shouldBeCalled();
 
         $this('000222', 1, 1000);
     }

--- a/spec/Creator/RefundCreatorSpec.php
+++ b/spec/Creator/RefundCreatorSpec.php
@@ -38,24 +38,28 @@ final class RefundCreatorSpec extends ObjectBehavior
         ObjectManager $refundEntityManager,
         RefundInterface $refund
     ): void {
-        $unitRefundingAvailabilityChecker->__invoke(1)->willReturn(true);
+        $refundType = RefundType::shipment();
+
+        $unitRefundingAvailabilityChecker->__invoke(1, $refundType)->willReturn(true);
 
         $refundFactory->createWithData('000222', 1, 1000, RefundType::shipment())->willReturn($refund);
 
         $refundEntityManager->persist($refund)->shouldBeCalled();
         $refundEntityManager->flush()->shouldBeCalled();
 
-        $this('000222', 1, 1000, RefundType::shipment());
+        $this('000222', 1, 1000, $refundType);
     }
 
     function it_throws_exception_if_unit_has_already_been_refunded(
         UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker
     ): void {
-        $unitRefundingAvailabilityChecker->__invoke(1)->willReturn(false);
+        $refundType = RefundType::shipment();
+
+        $unitRefundingAvailabilityChecker->__invoke(1, $refundType)->willReturn(false);
 
         $this
             ->shouldThrow(UnitAlreadyRefundedException::class)
-            ->during('__invoke', ['000222', 1, 1000, RefundType::orderUnit()])
+            ->during('__invoke', ['000222', 1, 1000, $refundType])
         ;
     }
 }

--- a/spec/Entity/RefundSpec.php
+++ b/spec/Entity/RefundSpec.php
@@ -9,6 +9,11 @@ use Sylius\RefundPlugin\Entity\RefundInterface;
 
 final class RefundSpec extends ObjectBehavior
 {
+    function let()
+    {
+        $this->beConstructedWith('000666', 1000, 3);
+    }
+
     function it_implements_refund_interface(): void
     {
         $this->shouldImplement(RefundInterface::class);
@@ -16,19 +21,16 @@ final class RefundSpec extends ObjectBehavior
 
     function it_has_order_number(): void
     {
-        $this->setOrderNumber('000666');
         $this->getOrderNumber()->shouldReturn('000666');
     }
 
     function it_has_amount(): void
     {
-        $this->setAmount(1000);
         $this->getAmount()->shouldReturn(1000);
     }
 
     function it_has_refunded_unit_id(): void
     {
-        $this->setRefundedUnitId(3);
         $this->getRefundedUnitId()->shouldReturn(3);
     }
 }

--- a/spec/Entity/RefundSpec.php
+++ b/spec/Entity/RefundSpec.php
@@ -10,9 +10,9 @@ use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundSpec extends ObjectBehavior
 {
-    function let()
+    function let(): void
     {
-        $this->beConstructedWith('000666', 1000, 3, RefundType::orderUnit());
+        $this->beConstructedWith('000666', 1000, 3, RefundType::orderItemUnit());
     }
 
     function it_implements_refund_interface(): void
@@ -37,6 +37,6 @@ final class RefundSpec extends ObjectBehavior
 
     function it_has_type(): void
     {
-        $this->getType()->shouldBeLike(RefundType::orderUnit());
+        $this->getType()->shouldBeLike(RefundType::orderItemUnit());
     }
 }

--- a/spec/Entity/RefundSpec.php
+++ b/spec/Entity/RefundSpec.php
@@ -6,12 +6,13 @@ namespace spec\Sylius\RefundPlugin\Entity;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Entity\RefundInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('000666', 1000, 3);
+        $this->beConstructedWith('000666', 1000, 3, RefundType::orderUnit());
     }
 
     function it_implements_refund_interface(): void
@@ -32,5 +33,10 @@ final class RefundSpec extends ObjectBehavior
     function it_has_refunded_unit_id(): void
     {
         $this->getRefundedUnitId()->shouldReturn(3);
+    }
+
+    function it_has_type(): void
+    {
+        $this->getType()->shouldBeLike(RefundType::orderUnit());
     }
 }

--- a/spec/Event/ShipmentRefundedSpec.php
+++ b/spec/Event/ShipmentRefundedSpec.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class ShipmentRefundedSpec extends ObjectBehavior
+{
+    function it_represents_an_immutable_fact_that_shipment_has_been_refunded(): void
+    {
+        $this->beConstructedWith('000222', 1, 1000);
+
+        $this->orderNumber()->shouldReturn('000222');
+        $this->shipmentUnitId()->shouldReturn(1);
+        $this->amount()->shouldReturn(1000);
+    }
+}

--- a/spec/Event/UnitsRefundedSpec.php
+++ b/spec/Event/UnitsRefundedSpec.php
@@ -8,12 +8,13 @@ use PhpSpec\ObjectBehavior;
 
 final class UnitsRefundedSpec extends ObjectBehavior
 {
-    function it_represents_an_immutable_fact_that_units_has_been_refunded(): void
+    function it_represents_an_immutable_fact_that_units_and_shipments_has_been_refunded(): void
     {
-        $this->beConstructedWith('000222', [1, 2, 3], 5000);
+        $this->beConstructedWith('000222', [1, 2, 3], [1], 5000);
 
         $this->orderNumber()->shouldReturn('000222');
         $this->unitIds()->shouldReturn([1, 2, 3]);
+        $this->shipmentIds()->shouldReturn([1]);
         $this->amount()->shouldReturn(5000);
     }
 }

--- a/spec/Factory/RefundFactorySpec.php
+++ b/spec/Factory/RefundFactorySpec.php
@@ -19,8 +19,8 @@ final class RefundFactorySpec extends ObjectBehavior
     function it_allows_to_create_refund_with_given_data(): void
     {
         $this
-            ->createWithData('0001', 1, 1000, RefundType::orderUnit())
-            ->shouldBeLike(new Refund('0001', 1000, 1, RefundType::orderUnit()))
+            ->createWithData('0001', 1, 1000, RefundType::orderItemUnit())
+            ->shouldBeLike(new Refund('0001', 1000, 1, RefundType::orderItemUnit()))
         ;
     }
 }

--- a/spec/Factory/RefundFactorySpec.php
+++ b/spec/Factory/RefundFactorySpec.php
@@ -17,11 +17,6 @@ final class RefundFactorySpec extends ObjectBehavior
 
     function it_allows_to_create_refund_with_given_data(): void
     {
-        $refund = new Refund();
-        $refund->setOrderNumber('0001');
-        $refund->setRefundedUnitId(1);
-        $refund->setAmount(1000);
-
-        $this->createWithData('0001', 1, 1000)->shouldBeLike($refund);
+        $this->createWithData('0001', 1, 1000)->shouldBeLike(new Refund('0001', 1000, 1));
     }
 }

--- a/spec/Factory/RefundFactorySpec.php
+++ b/spec/Factory/RefundFactorySpec.php
@@ -7,6 +7,7 @@ namespace spec\Sylius\RefundPlugin\Factory;
 use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Entity\Refund;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundFactorySpec extends ObjectBehavior
 {
@@ -17,6 +18,9 @@ final class RefundFactorySpec extends ObjectBehavior
 
     function it_allows_to_create_refund_with_given_data(): void
     {
-        $this->createWithData('0001', 1, 1000)->shouldBeLike(new Refund('0001', 1000, 1));
+        $this
+            ->createWithData('0001', 1, 1000, RefundType::orderUnit())
+            ->shouldBeLike(new Refund('0001', 1000, 1, RefundType::orderUnit()))
+        ;
     }
 }

--- a/spec/Listener/UnitsRefundedEventListenerSpec.php
+++ b/spec/Listener/UnitsRefundedEventListenerSpec.php
@@ -24,6 +24,6 @@ final class UnitsRefundedEventListenerSpec extends ObjectBehavior
 
         $flashBag->add('success', 'sylius_refund.units_successfully_refunded')->shouldBeCalled();
 
-        $this(new UnitsRefunded('000222', [1, 2], 1000));
+        $this(new UnitsRefunded('000222', [1, 2], [1], 1000));
     }
 }

--- a/spec/Provider/OrderRefundedTotalProviderSpec.php
+++ b/spec/Provider/OrderRefundedTotalProviderSpec.php
@@ -12,9 +12,9 @@ use Sylius\RefundPlugin\Provider\OrderRefundedTotalProviderInterface;
 
 final class OrderRefundedTotalProviderSpec extends ObjectBehavior
 {
-    function let(RepositoryInterface $refundRepository, RepositoryInterface $orderItemUnitRepository): void
+    function let(RepositoryInterface $refundRepository): void
     {
-        $this->beConstructedWith($refundRepository, $orderItemUnitRepository);
+        $this->beConstructedWith($refundRepository);
     }
 
     function it_implements_order_refunded_total_provider_interface(): void
@@ -24,22 +24,13 @@ final class OrderRefundedTotalProviderSpec extends ObjectBehavior
 
     function it_returns_refunded_total_of_order_with_given_number(
         RepositoryInterface $refundRepository,
-        RepositoryInterface $orderItemUnitRepository,
         RefundInterface $firstRefund,
-        RefundInterface $secondRefund,
-        OrderItemUnitInterface $firstOrderItemUnit,
-        OrderItemUnitInterface $secondOrderItemUnit
+        RefundInterface $secondRefund
     ): void {
         $refundRepository->findBy(['orderNumber' => '000222'])->willReturn([$firstRefund, $secondRefund]);
 
-        $firstRefund->getRefundedUnitId()->willReturn(10);
-        $secondRefund->getRefundedUnitId()->willReturn(5);
-
-        $orderItemUnitRepository->find(10)->willReturn($firstOrderItemUnit);
-        $orderItemUnitRepository->find(5)->willReturn($secondOrderItemUnit);
-
-        $firstOrderItemUnit->getTotal()->willReturn(1000);
-        $secondOrderItemUnit->getTotal()->willReturn(500);
+        $firstRefund->getAmount()->willReturn(1000);
+        $secondRefund->getAmount()->willReturn(500);
 
         $this->__invoke('000222')->shouldReturn(1500);
     }

--- a/spec/Provider/OrderRefundedTotalProviderSpec.php
+++ b/spec/Provider/OrderRefundedTotalProviderSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\RefundPlugin\Provider;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
 use Sylius\RefundPlugin\Provider\OrderRefundedTotalProviderInterface;

--- a/spec/Provider/RefundedShipmentFeeProviderSpec.php
+++ b/spec/Provider/RefundedShipmentFeeProviderSpec.php
@@ -6,10 +6,8 @@ namespace spec\Sylius\RefundPlugin\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
-use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 
 final class RefundedShipmentFeeProviderSpec extends ObjectBehavior
 {

--- a/spec/Provider/RefundedShipmentFeeProviderSpec.php
+++ b/spec/Provider/RefundedShipmentFeeProviderSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
+use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
+
+final class RefundedShipmentFeeProviderSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $adjustmentRepository): void
+    {
+        $this->beConstructedWith($adjustmentRepository);
+    }
+
+    function it_implements_refunded_shipment_fee_provider_interface()
+    {
+        $this->shouldImplement(RefundedShipmentFeeProviderInterface::class);
+    }
+
+    function it_returns_fee_from_shipping_adjustment(
+        RepositoryInterface $adjustmentRepository,
+        AdjustmentInterface $shippingAdjustment
+    ): void {
+        $adjustmentRepository->find(1)->willReturn($shippingAdjustment);
+        $shippingAdjustment->getAmount()->willReturn(1000);
+
+        $this->getFeeOfShipment(1)->shouldReturn(1000);
+    }
+
+    function it_throws_exception_if_there_is_no_adjustment_with_given_id(
+        RepositoryInterface $adjustmentRepository
+    ): void {
+        $adjustmentRepository->find(1)->willReturn(null);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('getFeeOfShipment', [1])
+        ;
+    }
+}

--- a/spec/Provider/RefundedShipmentFeeProviderSpec.php
+++ b/spec/Provider/RefundedShipmentFeeProviderSpec.php
@@ -28,6 +28,7 @@ final class RefundedShipmentFeeProviderSpec extends ObjectBehavior
         AdjustmentInterface $shippingAdjustment
     ): void {
         $adjustmentRepository->find(1)->willReturn($shippingAdjustment);
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->getAmount()->willReturn(1000);
 
         $this->getFeeOfShipment(1)->shouldReturn(1000);
@@ -37,6 +38,19 @@ final class RefundedShipmentFeeProviderSpec extends ObjectBehavior
         RepositoryInterface $adjustmentRepository
     ): void {
         $adjustmentRepository->find(1)->willReturn(null);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('getFeeOfShipment', [1])
+        ;
+    }
+
+    function it_throws_exception_if_adjustment_is_not_shipping_adjustment(
+        RepositoryInterface $adjustmentRepository,
+        AdjustmentInterface $adjustment
+    ): void {
+        $adjustmentRepository->find(1)->willReturn($adjustment);
+        $adjustment->getType()->willReturn('some_other_type');
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)

--- a/spec/Refunder/OrderItemUnitsRefunderSpec.php
+++ b/spec/Refunder/OrderItemUnitsRefunderSpec.php
@@ -13,7 +13,7 @@ use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 use Sylius\RefundPlugin\Refunder\RefunderInterface;
 
-final class OrderUnitsRefunderSpec extends ObjectBehavior
+final class OrderItemUnitsRefunderSpec extends ObjectBehavior
 {
     function let(
         RefundCreatorInterface $refundCreator,
@@ -36,7 +36,7 @@ final class OrderUnitsRefunderSpec extends ObjectBehavior
         $refundedUnitTotalProvider->getTotalOfUnitWithId(1)->willReturn(1500);
         $refundedUnitTotalProvider->getTotalOfUnitWithId(3)->willReturn(1000);
 
-        $refundCreator->__invoke('000222', 1, 1500, RefundType::orderUnit())->shouldBeCalled();
+        $refundCreator->__invoke('000222', 1, 1500, RefundType::orderItemUnit())->shouldBeCalled();
 
         $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
             return
@@ -46,7 +46,7 @@ final class OrderUnitsRefunderSpec extends ObjectBehavior
             ;
         }))->shouldBeCalled();
 
-        $refundCreator->__invoke('000222', 3, 1000, RefundType::orderUnit())->shouldBeCalled();
+        $refundCreator->__invoke('000222', 3, 1000, RefundType::orderItemUnit())->shouldBeCalled();
 
         $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
             return

--- a/spec/Refunder/OrderShipmentsRefunderSpec.php
+++ b/spec/Refunder/OrderShipmentsRefunderSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Refunder;
+
+use PhpSpec\ObjectBehavior;
+use Prooph\ServiceBus\EventBus;
+use Prophecy\Argument;
+use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
+use Sylius\RefundPlugin\Event\ShipmentRefunded;
+use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
+use Sylius\RefundPlugin\Refunder\RefunderInterface;
+
+final class OrderShipmentsRefunderSpec extends ObjectBehavior
+{
+    function let(
+        RefundCreatorInterface $refundCreator,
+        RefundedShipmentFeeProviderInterface $refundedShipmentFeeProvider,
+        EventBus $eventBus
+    ): void {
+        $this->beConstructedWith($refundCreator, $refundedShipmentFeeProvider, $eventBus);
+    }
+
+    function it_implements_refunder_interface(): void
+    {
+        $this->shouldImplement(RefunderInterface::class);
+    }
+
+    function it_creates_refund_for_each_shipment_and_dispatch_proper_event(
+        RefundCreatorInterface $refundCreator,
+        RefundedShipmentFeeProviderInterface $refundedShipmentFeeProvider,
+        EventBus $eventBus
+    ): void {
+        $refundedShipmentFeeProvider->getFeeOfShipment(4)->willReturn(2500);
+
+        $refundCreator->__invoke('000222', 4, 2500)->shouldBeCalled();
+
+        $eventBus->dispatch(Argument::that(function (ShipmentRefunded $event): bool {
+            return
+                $event->orderNumber() === '000222' &&
+                $event->shipmentUnitId() === 4 &&
+                $event->amount() === 2500
+            ;
+        }))->shouldBeCalled();
+
+        $this->refundFromOrder([4], '000222')->shouldReturn(2500);;
+    }
+}

--- a/spec/Refunder/OrderShipmentsRefunderSpec.php
+++ b/spec/Refunder/OrderShipmentsRefunderSpec.php
@@ -9,6 +9,7 @@ use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Event\ShipmentRefunded;
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
 use Sylius\RefundPlugin\Refunder\RefunderInterface;
 
@@ -34,7 +35,7 @@ final class OrderShipmentsRefunderSpec extends ObjectBehavior
     ): void {
         $refundedShipmentFeeProvider->getFeeOfShipment(4)->willReturn(2500);
 
-        $refundCreator->__invoke('000222', 4, 2500)->shouldBeCalled();
+        $refundCreator->__invoke('000222', 4, 2500, RefundType::shipment())->shouldBeCalled();
 
         $eventBus->dispatch(Argument::that(function (ShipmentRefunded $event): bool {
             return

--- a/spec/Refunder/OrderShipmentsRefunderSpec.php
+++ b/spec/Refunder/OrderShipmentsRefunderSpec.php
@@ -45,6 +45,6 @@ final class OrderShipmentsRefunderSpec extends ObjectBehavior
             ;
         }))->shouldBeCalled();
 
-        $this->refundFromOrder([4], '000222')->shouldReturn(2500);;
+        $this->refundFromOrder([4], '000222')->shouldReturn(2500);
     }
 }

--- a/spec/Refunder/OrderUnitsRefunderSpec.php
+++ b/spec/Refunder/OrderUnitsRefunderSpec.php
@@ -56,6 +56,6 @@ final class OrderUnitsRefunderSpec extends ObjectBehavior
             ;
         }))->shouldBeCalled();
 
-        $this->refundFromOrder([1, 3], '000222')->shouldReturn(2500);;
+        $this->refundFromOrder([1, 3], '000222')->shouldReturn(2500);
     }
 }

--- a/spec/Refunder/OrderUnitsRefunderSpec.php
+++ b/spec/Refunder/OrderUnitsRefunderSpec.php
@@ -9,6 +9,7 @@ use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 use Sylius\RefundPlugin\Refunder\RefunderInterface;
 
@@ -35,7 +36,7 @@ final class OrderUnitsRefunderSpec extends ObjectBehavior
         $refundedUnitTotalProvider->getTotalOfUnitWithId(1)->willReturn(1500);
         $refundedUnitTotalProvider->getTotalOfUnitWithId(3)->willReturn(1000);
 
-        $refundCreator->__invoke('000222', 1, 1500)->shouldBeCalled();
+        $refundCreator->__invoke('000222', 1, 1500, RefundType::orderUnit())->shouldBeCalled();
 
         $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
             return
@@ -45,7 +46,7 @@ final class OrderUnitsRefunderSpec extends ObjectBehavior
             ;
         }))->shouldBeCalled();
 
-        $refundCreator->__invoke('000222', 3, 1000)->shouldBeCalled();
+        $refundCreator->__invoke('000222', 3, 1000, RefundType::orderUnit())->shouldBeCalled();
 
         $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
             return

--- a/spec/Refunder/OrderUnitsRefunderSpec.php
+++ b/spec/Refunder/OrderUnitsRefunderSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Refunder;
+
+use PhpSpec\ObjectBehavior;
+use Prooph\ServiceBus\EventBus;
+use Prophecy\Argument;
+use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
+use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
+use Sylius\RefundPlugin\Refunder\RefunderInterface;
+
+final class OrderUnitsRefunderSpec extends ObjectBehavior
+{
+    function let(
+        RefundCreatorInterface $refundCreator,
+        RefundedUnitTotalProviderInterface $refundedUnitTotalProvider,
+        EventBus $eventBus
+    ): void {
+        $this->beConstructedWith($refundCreator, $refundedUnitTotalProvider, $eventBus);
+    }
+
+    function it_implements_refunder_interface(): void
+    {
+        $this->shouldImplement(RefunderInterface::class);
+    }
+
+    function it_creates_refund_for_each_unit_and_dispatch_proper_event(
+        RefundCreatorInterface $refundCreator,
+        RefundedUnitTotalProviderInterface $refundedUnitTotalProvider,
+        EventBus $eventBus
+    ): void {
+        $refundedUnitTotalProvider->getTotalOfUnitWithId(1)->willReturn(1500);
+        $refundedUnitTotalProvider->getTotalOfUnitWithId(3)->willReturn(1000);
+
+        $refundCreator->__invoke('000222', 1, 1500)->shouldBeCalled();
+
+        $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
+            return
+                $event->orderNumber() === '000222' &&
+                $event->unitId() === 1 &&
+                $event->amount() === 1500
+            ;
+        }))->shouldBeCalled();
+
+        $refundCreator->__invoke('000222', 3, 1000)->shouldBeCalled();
+
+        $eventBus->dispatch(Argument::that(function (UnitRefunded $event): bool {
+            return
+                $event->orderNumber() === '000222' &&
+                $event->unitId() === 3 &&
+                $event->amount() === 1000
+            ;
+        }))->shouldBeCalled();
+
+        $this->refundFromOrder([1, 3], '000222')->shouldReturn(2500);;
+    }
+}

--- a/src/Action/OrderRefundsListAction.php
+++ b/src/Action/OrderRefundsListAction.php
@@ -28,8 +28,8 @@ final class OrderRefundsListAction
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
-        Environment $twig)
-    {
+        Environment $twig
+    ) {
         $this->orderRepository = $orderRepository;
         $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
         $this->twig = $twig;

--- a/src/Checker/UnitRefundingAvailabilityChecker.php
+++ b/src/Checker/UnitRefundingAvailabilityChecker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Checker;
 
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class UnitRefundingAvailabilityChecker implements UnitRefundingAvailabilityCheckerInterface
 {
@@ -16,8 +17,11 @@ final class UnitRefundingAvailabilityChecker implements UnitRefundingAvailabilit
         $this->refundRepository = $refundRepository;
     }
 
-    public function __invoke(int $unitId): bool
+    public function __invoke(int $unitId, RefundType $refundType): bool
     {
-        return null == $this->refundRepository->findOneBy(['refundedUnitId' => $unitId]);
+        return null == $this
+            ->refundRepository
+            ->findOneBy(['refundedUnitId' => $unitId, 'type' => $refundType->__toString()])
+        ;
     }
 }

--- a/src/Checker/UnitRefundingAvailabilityCheckerInterface.php
+++ b/src/Checker/UnitRefundingAvailabilityCheckerInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Checker;
 
+use Sylius\RefundPlugin\Model\RefundType;
+
 interface UnitRefundingAvailabilityCheckerInterface
 {
-    public function __invoke(int $unitId): bool;
+    public function __invoke(int $unitId, RefundType $refundType): bool;
 }

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -11,13 +11,13 @@ final class RefundUnits extends Command
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $refundedUnitIds, array $refundedShipmentIds)
+    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds)
     {
         $this->init();
         $this->setPayload([
             'order_number' => $orderNumber,
-            'refunded_unit_ids' => $refundedUnitIds,
-            'refunded_shipment_ids' => $refundedShipmentIds,
+            'unit_ids' => $unitIds,
+            'shipment_ids' => $shipmentIds,
         ]);
     }
 
@@ -26,13 +26,13 @@ final class RefundUnits extends Command
         return $this->payload()['order_number'];
     }
 
-    public function refundedUnitIds(): array
+    public function unitIds(): array
     {
-        return $this->payload()['refunded_unit_ids'];
+        return $this->payload()['unit_ids'];
     }
 
-    public function refundedShipmentIds(): array
+    public function shipmentIds(): array
     {
-        return $this->payload()['refunded_shipment_ids'];
+        return $this->payload()['shipment_ids'];
     }
 }

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -11,12 +11,13 @@ final class RefundUnits extends Command
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $refundedUnitIds)
+    public function __construct(string $orderNumber, array $refundedUnitIds, array $refundedShipmentIds)
     {
         $this->init();
         $this->setPayload([
             'order_number' => $orderNumber,
             'refunded_unit_ids' => $refundedUnitIds,
+            'refunded_shipment_ids' => $refundedShipmentIds,
         ]);
     }
 
@@ -28,5 +29,10 @@ final class RefundUnits extends Command
     public function refundedUnitIds(): array
     {
         return $this->payload()['refunded_unit_ids'];
+    }
+
+    public function refundedShipmentIds(): array
+    {
+        return $this->payload()['refunded_shipment_ids'];
     }
 }

--- a/src/CommandHandler/RefundUnitsHandler.php
+++ b/src/CommandHandler/RefundUnitsHandler.php
@@ -46,13 +46,13 @@ final class RefundUnitsHandler
         $orderNumber = $command->orderNumber();
 
         $refundedTotal = 0;
-        $refundedTotal += $this->orderUnitsRefunder->refundFromOrder($command->refundedUnitIds(), $orderNumber);
-        $refundedTotal += $this->orderShipmentsRefunder->refundFromOrder($command->refundedShipmentIds(), $orderNumber);
+        $refundedTotal += $this->orderUnitsRefunder->refundFromOrder($command->unitIds(), $orderNumber);
+        $refundedTotal += $this->orderShipmentsRefunder->refundFromOrder($command->shipmentIds(), $orderNumber);
 
         $this->eventBus->dispatch(new UnitsRefunded(
             $orderNumber,
-            $command->refundedUnitIds(),
-            $command->refundedShipmentIds(),
+            $command->unitIds(),
+            $command->shipmentIds(),
             $refundedTotal
         ));
     }

--- a/src/Creator/RefundCreator.php
+++ b/src/Creator/RefundCreator.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundCreator implements RefundCreatorInterface
 {
@@ -30,13 +31,13 @@ final class RefundCreator implements RefundCreatorInterface
         $this->refundManager = $refundManager;
     }
 
-    public function __invoke(string $orderNumber, int $unitId, int $amount): void
+    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundType $refundType): void
     {
         if (!$this->unitRefundingAvailabilityChecker->__invoke($unitId)) {
             throw UnitAlreadyRefundedException::withIdAndOrderNumber($unitId, $orderNumber);
         }
 
-        $refund = $this->refundFactory->createWithData($orderNumber, $unitId, $amount);
+        $refund = $this->refundFactory->createWithData($orderNumber, $unitId, $amount, $refundType);
 
         $this->refundManager->persist($refund);
         $this->refundManager->flush();

--- a/src/Creator/RefundCreator.php
+++ b/src/Creator/RefundCreator.php
@@ -33,7 +33,7 @@ final class RefundCreator implements RefundCreatorInterface
 
     public function __invoke(string $orderNumber, int $unitId, int $amount, RefundType $refundType): void
     {
-        if (!$this->unitRefundingAvailabilityChecker->__invoke($unitId)) {
+        if (!$this->unitRefundingAvailabilityChecker->__invoke($unitId, $refundType)) {
             throw UnitAlreadyRefundedException::withIdAndOrderNumber($unitId, $orderNumber);
         }
 

--- a/src/Creator/RefundCreator.php
+++ b/src/Creator/RefundCreator.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Creator;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Prooph\ServiceBus\EventBus;
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
-use Sylius\RefundPlugin\Event\UnitRefunded;
 use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
 
@@ -22,19 +20,14 @@ final class RefundCreator implements RefundCreatorInterface
     /** @var ObjectManager */
     private $refundManager;
 
-    /** @var EventBus */
-    private $eventBus;
-
     public function __construct(
         RefundFactoryInterface $refundFactory,
         UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
-        ObjectManager $refundManager,
-        EventBus $eventBus
+        ObjectManager $refundManager
     ) {
         $this->refundFactory = $refundFactory;
         $this->unitRefundingAvailabilityChecker = $unitRefundingAvailabilityChecker;
         $this->refundManager = $refundManager;
-        $this->eventBus = $eventBus;
     }
 
     public function __invoke(string $orderNumber, int $unitId, int $amount): void
@@ -47,7 +40,5 @@ final class RefundCreator implements RefundCreatorInterface
 
         $this->refundManager->persist($refund);
         $this->refundManager->flush();
-
-        $this->eventBus->dispatch(new UnitRefunded($orderNumber, $unitId, $amount));
     }
 }

--- a/src/Creator/RefundCreatorInterface.php
+++ b/src/Creator/RefundCreatorInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Creator;
 
+use Sylius\RefundPlugin\Model\RefundType;
+
 interface RefundCreatorInterface
 {
-    public function __invoke(string $orderNumber, int $unitId, int $amount): void;
+    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundType $refundType): void;
 }

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Entity;
+
 use Sylius\RefundPlugin\Model\RefundType;
 
 /** @final */
@@ -11,13 +12,13 @@ class Refund implements RefundInterface
     /** @var int|null */
     private $id;
 
-    /** @var string|null */
+    /** @var string */
     private $orderNumber;
 
-    /** @var int|null */
+    /** @var int */
     private $amount;
 
-    /** @var int|null */
+    /** @var int */
     private $refundedUnitId;
 
     /** @var RefundType */

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -19,38 +19,30 @@ class Refund implements RefundInterface
     /** @var int|null */
     private $refundedUnitId;
 
+    public function __construct(string $orderNumber, int $amount, int $refundedUnitId)
+    {
+        $this->orderNumber = $orderNumber;
+        $this->amount = $amount;
+        $this->refundedUnitId = $refundedUnitId;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getOrderNumber(): ?string
+    public function getOrderNumber(): string
     {
         return $this->orderNumber;
     }
 
-    public function setOrderNumber(?string $orderNumber): void
-    {
-        $this->orderNumber = $orderNumber;
-    }
-
-    public function getAmount(): ?int
+    public function getAmount(): int
     {
         return $this->amount;
     }
 
-    public function setAmount(?int $amount): void
-    {
-        $this->amount = $amount;
-    }
-
-    public function getRefundedUnitId(): ?int
+    public function getRefundedUnitId(): int
     {
         return $this->refundedUnitId;
-    }
-
-    public function setRefundedUnitId(?int $refundedUnitId): void
-    {
-        $this->refundedUnitId = $refundedUnitId;
     }
 }

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Entity;
+use Sylius\RefundPlugin\Model\RefundType;
 
 /** @final */
 class Refund implements RefundInterface
@@ -19,11 +20,15 @@ class Refund implements RefundInterface
     /** @var int|null */
     private $refundedUnitId;
 
-    public function __construct(string $orderNumber, int $amount, int $refundedUnitId)
+    /** @var RefundType */
+    private $type;
+
+    public function __construct(string $orderNumber, int $amount, int $refundedUnitId, RefundType $type)
     {
         $this->orderNumber = $orderNumber;
         $this->amount = $amount;
         $this->refundedUnitId = $refundedUnitId;
+        $this->type = $type;
     }
 
     public function getId(): ?int
@@ -44,5 +49,10 @@ class Refund implements RefundInterface
     public function getRefundedUnitId(): int
     {
         return $this->refundedUnitId;
+    }
+
+    public function getType(): RefundType
+    {
+        return $this->type;
     }
 }

--- a/src/Entity/RefundInterface.php
+++ b/src/Entity/RefundInterface.php
@@ -8,15 +8,9 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 
 interface RefundInterface extends ResourceInterface
 {
-    public function getOrderNumber(): ?string;
+    public function getOrderNumber(): string;
 
-    public function setOrderNumber(?string $orderNumber): void;
+    public function getAmount(): int;
 
-    public function getAmount(): ?int;
-
-    public function setAmount(?int $amount): void;
-
-    public function getRefundedUnitId(): ?int;
-
-    public function setRefundedUnitId(?int $refundedUnitId): void;
+    public function getRefundedUnitId(): int;
 }

--- a/src/Entity/RefundInterface.php
+++ b/src/Entity/RefundInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Entity;
 
 use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 interface RefundInterface extends ResourceInterface
 {
@@ -13,4 +14,6 @@ interface RefundInterface extends ResourceInterface
     public function getAmount(): int;
 
     public function getRefundedUnitId(): int;
+
+    public function getType(): RefundType;
 }

--- a/src/Event/ShipmentRefunded.php
+++ b/src/Event/ShipmentRefunded.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Event;
+
+final class ShipmentRefunded
+{
+    /** @var string */
+    private $orderNumber;
+
+    /** @var int */
+    private $shipmentUnitId;
+
+    /** @var int */
+    private $amount;
+
+    public function __construct(string $orderNumber, int $shipmentUnitId, int $amount)
+    {
+        $this->orderNumber = $orderNumber;
+        $this->shipmentUnitId = $shipmentUnitId;
+        $this->amount = $amount;
+    }
+
+    public function orderNumber(): string
+    {
+        return $this->orderNumber;
+    }
+
+    public function shipmentUnitId(): int
+    {
+        return $this->shipmentUnitId;
+    }
+
+    public function amount(): int
+    {
+        return $this->amount;
+    }
+}

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -11,21 +11,13 @@ final class UnitsRefunded extends DomainEvent
 {
     use PayloadTrait;
 
-    /** @var string */
-    private $orderNumber;
-
-    /** @var iterable */
-    private $unitIds;
-
-    /** @var int */
-    private $amount;
-
-    public function __construct(string $orderNumber, iterable $unitIds, int $amount)
+    public function __construct(string $orderNumber, iterable $unitIds, iterable $shipmentIds, int $amount)
     {
         $this->init();
         $this->setPayload([
             'order_number' => $orderNumber,
             'unit_ids' => $unitIds,
+            'shipment_ids' => $shipmentIds,
             'amount' => $amount,
         ]);
     }
@@ -38,6 +30,11 @@ final class UnitsRefunded extends DomainEvent
     public function unitIds(): iterable
     {
         return $this->payload['unit_ids'];
+    }
+
+    public function shipmentIds(): iterable
+    {
+        return $this->payload['shipment_ids'];
     }
 
     public function amount(): int

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -11,7 +11,7 @@ final class UnitsRefunded extends DomainEvent
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, iterable $unitIds, iterable $shipmentIds, int $amount)
+    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, int $amount)
     {
         $this->init();
         $this->setPayload([
@@ -27,12 +27,12 @@ final class UnitsRefunded extends DomainEvent
         return $this->payload['order_number'];
     }
 
-    public function unitIds(): iterable
+    public function unitIds(): array
     {
         return $this->payload['unit_ids'];
     }
 
-    public function shipmentIds(): iterable
+    public function shipmentIds(): array
     {
         return $this->payload['shipment_ids'];
     }

--- a/src/Exception/RefundTypeNotResolved.php
+++ b/src/Exception/RefundTypeNotResolved.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Exception;
+
+final class RefundTypeNotResolved extends \InvalidArgumentException
+{
+    public static function withType(string $type): self
+    {
+        return new self(sprintf('Refund type "%d" could not be resolved', $type));
+    }
+}

--- a/src/Factory/RefundFactory.php
+++ b/src/Factory/RefundFactory.php
@@ -6,11 +6,12 @@ namespace Sylius\RefundPlugin\Factory;
 
 use Sylius\RefundPlugin\Entity\Refund;
 use Sylius\RefundPlugin\Entity\RefundInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundFactory implements RefundFactoryInterface
 {
-    public function createWithData(string $orderNumber, int $unitId, int $amount): RefundInterface
+    public function createWithData(string $orderNumber, int $unitId, int $amount, RefundType $type): RefundInterface
     {
-        return new Refund($orderNumber, $amount, $unitId);
+        return new Refund($orderNumber, $amount, $unitId, $type);
     }
 }

--- a/src/Factory/RefundFactory.php
+++ b/src/Factory/RefundFactory.php
@@ -11,11 +11,6 @@ final class RefundFactory implements RefundFactoryInterface
 {
     public function createWithData(string $orderNumber, int $unitId, int $amount): RefundInterface
     {
-        $refund = new Refund();
-        $refund->setOrderNumber($orderNumber);
-        $refund->setRefundedUnitId($unitId);
-        $refund->setAmount($amount);
-
-        return $refund;
+        return new Refund($orderNumber, $amount, $unitId);
     }
 }

--- a/src/Factory/RefundFactoryInterface.php
+++ b/src/Factory/RefundFactoryInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Factory;
 
 use Sylius\RefundPlugin\Entity\RefundInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 
 interface RefundFactoryInterface
 {
-    public function createWithData(string $orderNumber, int $unitId, int $amount): RefundInterface;
+    public function createWithData(string $orderNumber, int $unitId, int $amount, RefundType $type): RefundInterface;
 }

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Model;
 
+use Sylius\RefundPlugin\Exception\RefundTypeNotResolved;
+
 final class RefundType
 {
+    public const ORDER_UNIT = 'order_unit';
+    public const SHIPMENT = 'shipment';
+
     /** @var string */
     private $value;
 
     public function __construct(string $value)
     {
+        if (!in_array($value, [self::ORDER_UNIT, self::SHIPMENT])) {
+            throw RefundTypeNotResolved::withType($value);
+        }
+
         $this->value = $value;
     }
 
@@ -21,11 +30,11 @@ final class RefundType
 
     public static function orderUnit(): self
     {
-        return new self('order_unit');
+        return new self(self::ORDER_UNIT);
     }
 
     public static function shipment(): self
     {
-        return new self('shipment');
+        return new self(self::SHIPMENT);
     }
 }

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Model;
+
+final class RefundType
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public static function orderUnit(): self
+    {
+        return new self('order_unit');
+    }
+
+    public static function shipment(): self
+    {
+        return new self('shipment');
+    }
+}

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -8,7 +8,7 @@ use Sylius\RefundPlugin\Exception\RefundTypeNotResolved;
 
 final class RefundType
 {
-    public const ORDER_UNIT = 'order_unit';
+    public const ORDER_ITEM_UNIT = 'order_item_unit';
     public const SHIPMENT = 'shipment';
 
     /** @var string */
@@ -16,7 +16,7 @@ final class RefundType
 
     public function __construct(string $value)
     {
-        if (!in_array($value, [self::ORDER_UNIT, self::SHIPMENT])) {
+        if (!in_array($value, [self::ORDER_ITEM_UNIT, self::SHIPMENT])) {
             throw RefundTypeNotResolved::withType($value);
         }
 
@@ -28,9 +28,9 @@ final class RefundType
         return $this->value;
     }
 
-    public static function orderUnit(): self
+    public static function orderItemUnit(): self
     {
-        return new self(self::ORDER_UNIT);
+        return new self(self::ORDER_ITEM_UNIT);
     }
 
     public static function shipment(): self

--- a/src/Provider/OrderRefundedTotalProvider.php
+++ b/src/Provider/OrderRefundedTotalProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
-use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
 
@@ -13,13 +12,9 @@ final class OrderRefundedTotalProvider implements OrderRefundedTotalProviderInte
     /** @var RepositoryInterface */
     private $refundRepository;
 
-    /** @var RepositoryInterface */
-    private $orderItemUnitRepository;
-
-    public function __construct(RepositoryInterface $refundRepository, RepositoryInterface $orderItemUnitRepository)
+    public function __construct(RepositoryInterface $refundRepository)
     {
         $this->refundRepository = $refundRepository;
-        $this->orderItemUnitRepository = $orderItemUnitRepository;
     }
 
     public function __invoke(string $orderNumber): int
@@ -29,10 +24,7 @@ final class OrderRefundedTotalProvider implements OrderRefundedTotalProviderInte
         $orderRefundedTotal = 0;
         /** @var RefundInterface $refund */
         foreach ($refunds as $refund) {
-            /** @var OrderItemUnitInterface $orderItemUnit */
-            $orderItemUnit = $this->orderItemUnitRepository->find($refund->getRefundedUnitId());
-
-            $orderRefundedTotal += $orderItemUnit->getTotal();
+            $orderRefundedTotal += $refund->getAmount();
         }
 
         return $orderRefundedTotal;

--- a/src/Provider/RefundedShipmentFeeProvider.php
+++ b/src/Provider/RefundedShipmentFeeProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Provider;
+
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final class RefundedShipmentFeeProvider implements RefundedShipmentFeeProviderInterface
+{
+    /** @var RepositoryInterface */
+    private $adjustmentRepository;
+
+    public function __construct(RepositoryInterface $adjustmentRepository)
+    {
+        $this->adjustmentRepository = $adjustmentRepository;
+    }
+
+    public function getFeeOfShipment(int $adjustmentId): int
+    {
+        /** @var AdjustmentInterface $adjustment */
+        $adjustment = $this->adjustmentRepository->find($adjustmentId);
+        Assert::notNull($adjustment);
+
+        return $adjustment->getAmount();
+    }
+}

--- a/src/Provider/RefundedShipmentFeeProvider.php
+++ b/src/Provider/RefundedShipmentFeeProvider.php
@@ -23,6 +23,7 @@ final class RefundedShipmentFeeProvider implements RefundedShipmentFeeProviderIn
         /** @var AdjustmentInterface $adjustment */
         $adjustment = $this->adjustmentRepository->find($adjustmentId);
         Assert::notNull($adjustment);
+        Assert::same($adjustment->getType(), AdjustmentInterface::SHIPPING_ADJUSTMENT);
 
         return $adjustment->getAmount();
     }

--- a/src/Provider/RefundedShipmentFeeProviderInterface.php
+++ b/src/Provider/RefundedShipmentFeeProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Provider;
+
+interface RefundedShipmentFeeProviderInterface
+{
+    public function getFeeOfShipment(int $adjustmentId): int;
+}

--- a/src/Refunder/OrderItemUnitsRefunder.php
+++ b/src/Refunder/OrderItemUnitsRefunder.php
@@ -10,7 +10,7 @@ use Sylius\RefundPlugin\Event\UnitRefunded;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 
-final class OrderUnitsRefunder implements RefunderInterface
+final class OrderItemUnitsRefunder implements RefunderInterface
 {
     /** @var RefundCreatorInterface */
     private $refundCreator;
@@ -37,7 +37,7 @@ final class OrderUnitsRefunder implements RefunderInterface
         foreach ($unitIds as $unitId) {
             $refundAmount = $this->refundedUnitTotalProvider->getTotalOfUnitWithId($unitId);
 
-            $this->refundCreator->__invoke($orderNumber, $unitId, $refundAmount, RefundType::orderUnit());
+            $this->refundCreator->__invoke($orderNumber, $unitId, $refundAmount, RefundType::orderItemUnit());
 
             $refundedTotal += $refundAmount;
 

--- a/src/Refunder/OrderShipmentsRefunder.php
+++ b/src/Refunder/OrderShipmentsRefunder.php
@@ -8,6 +8,7 @@ use Prooph\ServiceBus\EventBus;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Event\ShipmentRefunded;
 use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
 use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 
@@ -38,7 +39,7 @@ final class OrderShipmentsRefunder implements RefunderInterface
         foreach ($unitIds as $shipmentUnitId) {
             $refundAmount = $this->refundedShipmentFeeProvider->getFeeOfShipment($shipmentUnitId);
 
-            $this->refundCreator->__invoke($orderNumber, $shipmentUnitId, $refundAmount);
+            $this->refundCreator->__invoke($orderNumber, $shipmentUnitId, $refundAmount, RefundType::shipment());
 
             $refundedTotal += $refundAmount;
 

--- a/src/Refunder/OrderShipmentsRefunder.php
+++ b/src/Refunder/OrderShipmentsRefunder.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Refunder;
+
+use Prooph\ServiceBus\EventBus;
+use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
+use Sylius\RefundPlugin\Event\ShipmentRefunded;
+use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
+use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
+
+final class OrderShipmentsRefunder implements RefunderInterface
+{
+    /** @var RefundCreatorInterface */
+    private $refundCreator;
+
+    /** @var RefundedShipmentFeeProviderInterface */
+    private $refundedShipmentFeeProvider;
+
+    /** @var EventBus */
+    private $eventBus;
+
+    public function __construct(
+        RefundCreatorInterface $refundCreator,
+        RefundedShipmentFeeProviderInterface $refundedShipmentFeeProvider,
+        EventBus $eventBus
+    ) {
+        $this->refundCreator = $refundCreator;
+        $this->refundedShipmentFeeProvider = $refundedShipmentFeeProvider;
+        $this->eventBus = $eventBus;
+    }
+
+    public function refundFromOrder(array $unitIds, string $orderNumber): int
+    {
+        $refundedTotal = 0;
+        foreach ($unitIds as $shipmentUnitId) {
+            $refundAmount = $this->refundedShipmentFeeProvider->getFeeOfShipment($shipmentUnitId);
+
+            $this->refundCreator->__invoke($orderNumber, $shipmentUnitId, $refundAmount);
+
+            $refundedTotal += $refundAmount;
+
+            $this->eventBus->dispatch(new ShipmentRefunded($orderNumber, $shipmentUnitId, $refundAmount));
+        }
+
+        return $refundedTotal;
+    }
+}

--- a/src/Refunder/OrderShipmentsRefunder.php
+++ b/src/Refunder/OrderShipmentsRefunder.php
@@ -7,10 +7,8 @@ namespace Sylius\RefundPlugin\Refunder;
 use Prooph\ServiceBus\EventBus;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Event\ShipmentRefunded;
-use Sylius\RefundPlugin\Event\UnitRefunded;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedShipmentFeeProviderInterface;
-use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 
 final class OrderShipmentsRefunder implements RefunderInterface
 {

--- a/src/Refunder/OrderUnitsRefunder.php
+++ b/src/Refunder/OrderUnitsRefunder.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Refunder;
+
+use Prooph\ServiceBus\EventBus;
+use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
+use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
+
+final class OrderUnitsRefunder implements RefunderInterface
+{
+    /** @var RefundCreatorInterface */
+    private $refundCreator;
+
+    /** @var RefundedUnitTotalProviderInterface */
+    private $refundedUnitTotalProvider;
+
+    /** @var EventBus */
+    private $eventBus;
+
+    public function __construct(
+        RefundCreatorInterface $refundCreator,
+        RefundedUnitTotalProviderInterface $refundedUnitTotalProvider,
+        EventBus $eventBus
+    ) {
+        $this->refundCreator = $refundCreator;
+        $this->refundedUnitTotalProvider = $refundedUnitTotalProvider;
+        $this->eventBus = $eventBus;
+    }
+
+    public function refundFromOrder(array $unitIds, string $orderNumber): int
+    {
+        $refundedTotal = 0;
+        foreach ($unitIds as $unitId) {
+            $refundAmount = $this->refundedUnitTotalProvider->getTotalOfUnitWithId($unitId);
+
+            $this->refundCreator->__invoke($orderNumber, $unitId, $refundAmount);
+
+            $refundedTotal += $refundAmount;
+
+            $this->eventBus->dispatch(new UnitRefunded($orderNumber, $unitId, $refundAmount));
+        }
+
+        return $refundedTotal;
+    }
+}

--- a/src/Refunder/OrderUnitsRefunder.php
+++ b/src/Refunder/OrderUnitsRefunder.php
@@ -7,6 +7,7 @@ namespace Sylius\RefundPlugin\Refunder;
 use Prooph\ServiceBus\EventBus;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RefundedUnitTotalProviderInterface;
 
 final class OrderUnitsRefunder implements RefunderInterface
@@ -36,7 +37,7 @@ final class OrderUnitsRefunder implements RefunderInterface
         foreach ($unitIds as $unitId) {
             $refundAmount = $this->refundedUnitTotalProvider->getTotalOfUnitWithId($unitId);
 
-            $this->refundCreator->__invoke($orderNumber, $unitId, $refundAmount);
+            $this->refundCreator->__invoke($orderNumber, $unitId, $refundAmount, RefundType::orderUnit());
 
             $refundedTotal += $refundAmount;
 

--- a/src/Refunder/RefunderInterface.php
+++ b/src/Refunder/RefunderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Refunder;
+
+interface RefunderInterface
+{
+    /**
+     * @return int refunded units total
+     */
+    public function refundFromOrder(array $unitIds, string $orderNumber): int;
+}

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -18,7 +18,10 @@ final class RefundUnitsRequest
             $request->attributes->get('orderNumber'),
             array_map(function (string $unitId): int {
                 return (int) $unitId;
-            }, $request->request->get('sylius_refund_units'))
+            }, $request->request->get('sylius_refund_units', [])),
+            array_map(function (string $unitId): int {
+                return (int) $unitId;
+            }, $request->request->get('sylius_refund_shipments', []))
         );
     }
 }

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -12,7 +12,9 @@ final class RefundUnitsRequest
 {
     public static function getCommand(Request $request): RefundUnits
     {
-        Assert::notNull($request->request->get('sylius_refund_units'), 'sylius_refund.at_least_one_unit_should_be_selected_to_refund');
+        if ($request->request->get('sylius_refund_units') === null && $request->request->get('sylius_refund_shipments') === null) {
+            throw new \InvalidArgumentException('sylius_refund.at_least_one_unit_should_be_selected_to_refund');
+        }
 
         return new RefundUnits(
             $request->attributes->get('orderNumber'),

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -17,12 +17,15 @@ final class RefundUnitsRequest
 
         return new RefundUnits(
             $request->attributes->get('orderNumber'),
-            array_map(function (string $unitId): int {
-                return (int) $unitId;
-            }, $request->request->get('sylius_refund_units', [])),
-            array_map(function (string $unitId): int {
-                return (int) $unitId;
-            }, $request->request->get('sylius_refund_shipments', []))
+            self::parseIdsToIntegers($request->request->get('sylius_refund_units', [])),
+            self::parseIdsToIntegers($request->request->get('sylius_refund_shipments', []))
         );
+    }
+
+    private static function parseIdsToIntegers(array $elements): array
+    {
+        return array_map(function (string $element): int {
+            return (int) $element;
+        }, $elements);
     }
 }

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -6,7 +6,6 @@ namespace Sylius\RefundPlugin\Request;
 
 use Sylius\RefundPlugin\Command\RefundUnits;
 use Symfony\Component\HttpFoundation\Request;
-use Webmozart\Assert\Assert;
 
 final class RefundUnitsRequest
 {

--- a/src/Resources/config/doctrine/Refund.orm.xml
+++ b/src/Resources/config/doctrine/Refund.orm.xml
@@ -8,13 +8,18 @@
 >
 
     <entity name="Sylius\RefundPlugin\Entity\Refund" table="sylius_refund_refund">
+        <unique-constraints>
+            <unique-constraint columns="refunded_unit_id,type" />
+        </unique-constraints>
+
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
 
-        <field name="orderNumber" type="string" />
+        <field name="orderNumber"/>
         <field name="amount" type="integer" />
-        <field name="refundedUnitId" type="integer" nullable="true"/>
+        <field name="refundedUnitId" type="integer" nullable="true" column="refunded_unit_id"/>
+        <field name="type" />
     </entity>
 
 </doctrine-mapping>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -35,7 +35,6 @@
 
         <service id="Sylius\RefundPlugin\Provider\OrderRefundedTotalProvider">
             <argument type="service" id="sylius_refund.repository.refund" />
-            <argument type="service" id="sylius.repository.order_item_unit" />
         </service>
 
         <service id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,11 +13,24 @@
             <argument type="service" id="sylius_refund.factory.refund" />
             <argument type="service" id="Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityChecker" />
             <argument type="service" id="sylius_refund.manager.refund" />
+        </service>
+
+        <service id="Sylius\RefundPlugin\Refunder\OrderUnitsRefunder">
+            <argument type="service" id="Sylius\RefundPlugin\Creator\RefundCreator" />
+            <argument type="service" id="Sylius\RefundPlugin\Provider\RefundedUnitTotalProvider" />
+            <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />
+        </service>
+        <service id="Sylius\RefundPlugin\Refunder\OrderShipmentsRefunder">
+            <argument type="service" id="Sylius\RefundPlugin\Creator\RefundCreator" />
+            <argument type="service" id="Sylius\RefundPlugin\Provider\RefundedShipmentFeeProvider" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />
         </service>
 
         <service id="Sylius\RefundPlugin\Provider\RefundedUnitTotalProvider">
             <argument type="service" id="sylius.repository.order_item_unit" />
+        </service>
+        <service id="Sylius\RefundPlugin\Provider\RefundedShipmentFeeProvider">
+            <argument type="service" id="sylius.repository.adjustment" />
         </service>
 
         <service id="Sylius\RefundPlugin\Provider\OrderRefundedTotalProvider">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <argument type="service" id="sylius_refund.manager.refund" />
         </service>
 
-        <service id="Sylius\RefundPlugin\Refunder\OrderUnitsRefunder">
+        <service id="Sylius\RefundPlugin\Refunder\OrderItemUnitsRefunder">
             <argument type="service" id="Sylius\RefundPlugin\Creator\RefundCreator" />
             <argument type="service" id="Sylius\RefundPlugin\Provider\RefundedUnitTotalProvider" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />

--- a/src/Resources/config/services/command_bus.xml
+++ b/src/Resources/config/services/command_bus.xml
@@ -7,8 +7,8 @@
         <service id="Prooph\ServiceBus\CommandBus" alias="prooph_service_bus.sylius_refund_command_bus" />
 
         <service id="Sylius\RefundPlugin\CommandHandler\RefundUnitsHandler">
-            <argument type="service" id="Sylius\RefundPlugin\Creator\RefundCreator" />
-            <argument type="service" id="Sylius\RefundPlugin\Provider\RefundedUnitTotalProvider" />
+            <argument type="service" id="Sylius\RefundPlugin\Refunder\OrderUnitsRefunder" />
+            <argument type="service" id="Sylius\RefundPlugin\Refunder\OrderShipmentsRefunder" />
             <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />
             <tag name="prooph_service_bus.sylius_refund_command_bus.route_target" message-detection="true" />

--- a/src/Resources/config/services/command_bus.xml
+++ b/src/Resources/config/services/command_bus.xml
@@ -7,7 +7,7 @@
         <service id="Prooph\ServiceBus\CommandBus" alias="prooph_service_bus.sylius_refund_command_bus" />
 
         <service id="Sylius\RefundPlugin\CommandHandler\RefundUnitsHandler">
-            <argument type="service" id="Sylius\RefundPlugin\Refunder\OrderUnitsRefunder" />
+            <argument type="service" id="Sylius\RefundPlugin\Refunder\OrderItemUnitsRefunder" />
             <argument type="service" id="Sylius\RefundPlugin\Refunder\OrderShipmentsRefunder" />
             <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -1,4 +1,4 @@
 sylius_refund:
     at_least_one_unit_should_be_selected_to_refund: 'At least one unit should be selected to refund'
     order_should_be_paid: 'Order should be paid for the units to could be refunded'
-    units_successfully_refunded: 'Order units have been successfully refunded'
+    units_successfully_refunded: 'Selected order units have been successfully refunded'

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -71,7 +71,7 @@
                                         {{ money.format(unit.total, order.currencyCode) }}
                                     </td>
                                     <td class="aligned collapsing">
-                                        <div class="ui checkbox {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_UNIT')) %} disabled{% endif %}">
+                                        <div class="ui checkbox {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}">
                                             <input type="checkbox" name="sylius_refund_units[]" value="{{ unit.id }}">
                                         </div>
                                     </td>

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -71,7 +71,7 @@
                                         {{ money.format(unit.total, order.currencyCode) }}
                                     </td>
                                     <td class="aligned collapsing">
-                                        <div class="ui checkbox {% if not can_unit_be_refunded(unit.id) %} disabled{% endif %}">
+                                        <div class="ui checkbox {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_UNIT')) %} disabled{% endif %}">
                                             <input type="checkbox" name="sylius_refund_units[]" value="{{ unit.id }}">
                                         </div>
                                     </td>

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -78,6 +78,20 @@
                                 </tr>
                             {% endfor %}
                         {% endfor %}
+                        {% set shipment = order.getAdjustments('shipping').first() %}
+                            <tr class="shipment">
+                                <td class="single line">
+                                    {{ 'sylius.ui.shipment'|trans }}: {{ shipment.label }}
+                                </td>
+                                <td class="right aligned total">
+                                    {{ money.format(shipment.amount, order.currencyCode) }}
+                                </td>
+                                <td class="aligned collapsing">
+                                    <div class="ui checkbox {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}">
+                                        <input type="checkbox" name="sylius_refund_shipments[]" value="{{ shipment.id }}">
+                                    </div>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
 

--- a/src/Twig/OrderRefundsExtension.php
+++ b/src/Twig/OrderRefundsExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Twig;
 
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\OrderRefundedTotalProviderInterface;
 
 final class OrderRefundsExtension extends \Twig_Extension
@@ -32,8 +33,13 @@ final class OrderRefundsExtension extends \Twig_Extension
             ),
             new \Twig_Function(
                 'can_unit_be_refunded',
-                [$this->unitRefundingAvailabilityChecker, '__invoke']
+                [$this, 'canUnitBeRefunded']
             ),
         ];
+    }
+
+    public function canUnitBeRefunded(int $unitId, string $refundType): bool
+    {
+        return $this->unitRefundingAvailabilityChecker->__invoke($unitId, new RefundType($refundType));
     }
 }

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -54,7 +54,7 @@ final class RefundingContext implements Context
     {
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
-        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()]));
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
     }
 
     /**
@@ -84,7 +84,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()]));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -100,7 +100,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()]));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
         } catch (CommandDispatchException $exception) {
             throw new \Exception('RefundUnits command should not fail');
         }

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -92,7 +92,7 @@ final class RefundingContext implements Context
             return $refund->getAmount();
         }, $orderRefunds));
 
-        Assert::same($refundedTotal, $orderRefundedTotal);
+        Assert::same($orderRefundedTotal, $refundedTotal);
     }
 
     /**

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -143,7 +143,6 @@ final class RefundingContext implements Context
 
     /**
      * @Then I should be notified that selected order units have been successfully refunded
-     * @Then I should be notified that order shipment has been successfully refunded
      */
     public function notificationSteps(): void
     {

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -69,7 +69,7 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @When  /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
+     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
      */
     public function decideToRefundProductAndShipment(int $unitNumber, string $productName): void
     {

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -7,6 +7,7 @@ namespace Tests\Sylius\RefundPlugin\Behat\Context\Application;
 use Behat\Behat\Context\Context;
 use Prooph\ServiceBus\CommandBus;
 use Prooph\ServiceBus\Exception\CommandDispatchException;
+use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -58,20 +59,38 @@ final class RefundingContext implements Context
     }
 
     /**
+     * @When I decide to refund order shipment
+     */
+    public function decideToRefundOrderShipment(): void
+    {
+        $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
+
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()]));
+    }
+
+    /**
+     * @When  /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
+     */
+    public function decideToRefundProductAndShipment(int $unitNumber, string $productName): void
+    {
+        $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
+        $unit = $this->getOrderUnit($unitNumber, $productName);
+
+        $this->commandBus->dispatch(
+            new RefundUnits($this->order->getNumber(), [$unit->getId()], [$shippingAdjustment->getId()])
+        );
+    }
+
+    /**
      * @Then /^this order refunded total should be ("[^"]+")$/
      */
     public function refundedTotalShouldBe(int $refundedTotal): void
     {
-        $refundedUnitIds = array_map(function(RefundInterface $refund): int {
-            return $refund->getRefundedUnitId();
-        }, $this->refundRepository->findBy(['orderNumber' => $this->order->getNumber()]));
+        $orderRefunds = $this->refundRepository->findBy(['orderNumber' => $this->order->getNumber()]);
 
-        $orderRefundedTotal = 0;
-        foreach ($this->order->getItemUnits() as $unit) {
-            if (in_array($unit->getId(), $refundedUnitIds)) {
-                $orderRefundedTotal += $unit->getTotal();
-            }
-        }
+        $orderRefundedTotal = array_sum(array_map(function(RefundInterface $refund): int {
+            return $refund->getAmount();
+        }, $orderRefunds));
 
         Assert::same($refundedTotal, $orderRefundedTotal);
     }
@@ -85,6 +104,22 @@ final class RefundingContext implements Context
 
         try {
             $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
+        } catch (CommandDispatchException $exception) {
+            return;
+        }
+
+        throw new \Exception('RefundUnits command should fail');
+    }
+
+    /**
+     * @Then I should not be able to refund order shipment
+     */
+    public function shouldNotBeAbleToRefundOrderShipment(): void
+    {
+        $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
+
+        try {
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()]));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -108,8 +143,9 @@ final class RefundingContext implements Context
 
     /**
      * @Then I should be notified that selected order units have been successfully refunded
+     * @Then I should be notified that order shipment has been successfully refunded
      */
-    public function shouldBeNotifiedThatSelectedOrderUnitsHaveBeenSuccessfullyRefunded(): void
+    public function notificationSteps(): void
     {
         // intentionally left blank - not relevant in application scope
     }

--- a/tests/Behat/Context/Setup/RefundingContext.php
+++ b/tests/Behat/Context/Setup/RefundingContext.php
@@ -41,6 +41,6 @@ final class RefundingContext implements Context
 
         $unit = $unitsWithProduct->get($unitNumber-1);
 
-        $this->commandBus->dispatch(new RefundUnits($orderNumber, [$unit->getId()]));
+        $this->commandBus->dispatch(new RefundUnits($orderNumber, [$unit->getId()], []));
     }
 }

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -134,7 +134,7 @@ final class RefundingContext implements Context
      */
     public function refundedTotalShouldBe(string $refundedTotal): void
     {
-        Assert::same($refundedTotal, $this->orderRefundsPage->getRefundedTotal());
+        Assert::same($this->orderRefundsPage->getRefundedTotal(), $refundedTotal);
     }
 
     /**

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -65,6 +65,25 @@ final class RefundingContext implements Context
     }
 
     /**
+     * @When I decide to refund order shipment
+     */
+    public function decideToRefundOrderShipment(): void
+    {
+        $this->orderRefundsPage->pickOrderShipment();
+        $this->orderRefundsPage->refund();
+    }
+
+    /**
+     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
+     */
+    public function decideToRefundProductAndShipment(int $unitNumber, string $productName): void
+    {
+        $this->orderRefundsPage->pickUnitWithProductToRefund($productName, $unitNumber-1);
+        $this->orderRefundsPage->pickOrderShipment();
+        $this->orderRefundsPage->refund();
+    }
+
+    /**
      * @When I refund zero items
      */
     public function refundZeroItems(): void
@@ -100,6 +119,17 @@ final class RefundingContext implements Context
     }
 
     /**
+     * @Then I should be notified that order shipment has been successfully refunded
+     */
+    public function shouldBeNotifiedThatOrderShipmentHasBeenSuccessfullyRefunded(): void
+    {
+        $this->notificationChecker->checkNotification(
+            'Order shipment has been successfully refunded',
+            NotificationType::success()
+        );
+    }
+
+    /**
      * @Then I should be notified that at least one unit should be selected to refund
      */
     public function shouldBeNotifiedThatAtLeastOneUnitShouldBeSelectedToRefund(): void
@@ -124,6 +154,14 @@ final class RefundingContext implements Context
     public function shouldNotBeAbleToRefundUnitWithProduct(int $unitNumber, string $productName): void
     {
         Assert::false($this->orderRefundsPage->isUnitWithProductAvailableToRefund($productName, $unitNumber-1));
+    }
+
+    /**
+     * @Then I should not be able to refund order shipment
+     */
+    public function shouldNotBeAbleToRefundOrderShipment(): void
+    {
+        Assert::false($this->orderRefundsPage->isOrderShipmentAvailableToRefund());
     }
 
     /**

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -113,18 +113,7 @@ final class RefundingContext implements Context
     public function shouldBeNotifiedThatSelectedOrderUnitsHaveBeenSuccessfullyRefunded(): void
     {
         $this->notificationChecker->checkNotification(
-            'Order units have been successfully refunded',
-            NotificationType::success()
-        );
-    }
-
-    /**
-     * @Then I should be notified that order shipment has been successfully refunded
-     */
-    public function shouldBeNotifiedThatOrderShipmentHasBeenSuccessfullyRefunded(): void
-    {
-        $this->notificationChecker->checkNotification(
-            'Order shipment has been successfully refunded',
+            'Selected order units have been successfully refunded',
             NotificationType::success()
         );
     }

--- a/tests/Behat/Page/OrderRefundsPage.php
+++ b/tests/Behat/Page/OrderRefundsPage.php
@@ -83,6 +83,6 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
 
     private function isRefundable(NodeElement $element): bool
     {
-        return $element->find('css', '.checkbox')->hasClass('disabled');
+        return !$element->find('css', '.checkbox')->hasClass('disabled');
     }
 }

--- a/tests/Behat/Page/OrderRefundsPage.php
+++ b/tests/Behat/Page/OrderRefundsPage.php
@@ -36,6 +36,13 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
         $this->getDocument()->find('css', '#refund-all')->click();
     }
 
+    public function pickOrderShipment(): void
+    {
+        $orderShipment = $this->getOrderShipment();
+
+        $orderShipment->find('css', '.checkbox input')->check();
+    }
+
     public function refund(): void
     {
         $this->getDocument()->pressButton('Refund');
@@ -43,9 +50,12 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
 
     public function isUnitWithProductAvailableToRefund(string $productName, int $unitNumber): bool
     {
-        $units = $this->getUnitsWithProduct($productName);
+        return $this->isRefundable($this->getUnitsWithProduct($productName)[$unitNumber]);
+    }
 
-        return !$units[$unitNumber]->find('css', '.checkbox')->hasClass('disabled');
+    public function isOrderShipmentAvailableToRefund(): bool
+    {
+        return $this->isRefundable($this->getOrderShipment());
     }
 
     public function hasBackButton(): bool
@@ -64,5 +74,15 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
     private function getUnitsWithProduct(string $productName): array
     {
         return $this->getDocument()->findAll('css', sprintf('#refunds .unit:contains("%s")', $productName));
+    }
+
+    private function getOrderShipment(): NodeElement
+    {
+        return $this->getDocument()->find('css', '#refunds .shipment');
+    }
+
+    private function isRefundable(NodeElement $element): bool
+    {
+        return $element->find('css', '.checkbox')->hasClass('disabled');
     }
 }

--- a/tests/Behat/Page/OrderRefundsPageInterface.php
+++ b/tests/Behat/Page/OrderRefundsPageInterface.php
@@ -16,9 +16,13 @@ interface OrderRefundsPageInterface extends SymfonyPageInterface
 
     public function pickAllUnitsToRefund(): void;
 
+    public function pickOrderShipment(): void;
+
     public function refund(): void;
 
     public function isUnitWithProductAvailableToRefund(string $productName, int $unitNumber): bool;
+
+    public function isOrderShipmentAvailableToRefund(): bool;
 
     public function hasBackButton(): bool;
 }


### PR DESCRIPTION
The only thing I'm not sure about is `RefundUnits` command, with which now we can also refund shipments. On one hand, it's quite confusing (the natural thing is we think about `order units`)... On the other hand, we can say that in a context of `Refund` everything is a **refund unit**, no matter is it a shipment or order unit. And I have no idea how can it be named better 😄 

> Note

For now, there is only a support for one order shipment - the reason why, is that there could be some troubles about shipments in Sylius (we have one shipping adjustment even for multiple shipments) and even though Sylius supports multiple shipments, it's base on single-shipment architecture right now.

<img width="1172" alt="zrzut ekranu 2018-07-19 o 08 49 05" src="https://user-images.githubusercontent.com/6212718/42926093-a584a5d0-8b30-11e8-9102-17a44332f38f.png">
