### PR TITLE
I want to choose an offline payment method

### DIFF
--- a/features/completing_refund_payment.feature
+++ b/features/completing_refund_payment.feature
@@ -1,8 +1,8 @@
 @refunds
-Feature: Marking refund payment as paid
+Feature: Completing refund payment
     In order have consistent data on refund payments' status
     As an Administrator
-    I want to mark refund payment as paid
+    I want to complete refund payment
 
     Background:
         Given the store operates on a single channel in "United States"
@@ -18,7 +18,13 @@ Feature: Marking refund payment as paid
         And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
 
     @ui
-    Scenario: Marking refund payment as paid
+    Scenario: Completing refund payment
         Given I view the summary of the order "#00000022"
         When I complete the first refund payment
         Then I should see 1 refund payment with status "Completed"
+
+    @ui
+    Scenario: Being unable to complete already completed payment
+        Given I view the summary of the order "#00000022"
+        When I complete the first refund payment
+        Then I should not be able to complete the first refund payment

--- a/features/completing_refund_payment.feature
+++ b/features/completing_refund_payment.feature
@@ -19,12 +19,12 @@ Feature: Completing refund payment
 
     @ui
     Scenario: Completing refund payment
-        Given I view the summary of the order "#00000022"
-        When I complete the first refund payment
+        When I view the summary of the order "#00000022"
+        And I complete the first refund payment
         Then I should see 1 refund payment with status "Completed"
 
     @ui
     Scenario: Being unable to complete already completed payment
-        Given I view the summary of the order "#00000022"
-        When I complete the first refund payment
-        Then I should not be able to complete the first refund payment
+        When I view the summary of the order "#00000022"
+        And I complete the first refund payment
+        Then I should not be able to complete the first refund payment again

--- a/features/having_credit_memo_generated.feature
+++ b/features/having_credit_memo_generated.feature
@@ -23,7 +23,7 @@ Feature: Having credit memo generated
     @ui @application
     Scenario: Having credit memo generated after refund process
         When I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And I should have 1 credit memo generated for order "#00000022"
 

--- a/features/having_credit_memo_sent_to_customer.feature
+++ b/features/having_credit_memo_sent_to_customer.feature
@@ -18,6 +18,6 @@ Feature: Having credit memo sent to customer
     @application
     Scenario: Having credit memo file sent to a customer
         When I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And email to "rick.sanchez@wubba-lubba-dub-dub.com" with credit memo should be sent

--- a/features/having_order_fully_refunded.feature
+++ b/features/having_order_fully_refunded.feature
@@ -14,7 +14,7 @@ Feature: Having order fully refunded
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And I am logged in as an administrator
         And the order "#00000022" is already paid
-        And all units and shipment from the order "#00000022" are refunded
+        And all units and shipment from the order "#00000022" are refunded with "Space money" payment
 
     @ui
     Scenario: Having order fully refunded when both items and shipping are refunded

--- a/features/marking_refund_payment_as_paid.feature
+++ b/features/marking_refund_payment_as_paid.feature
@@ -1,0 +1,23 @@
+@refunds
+Feature: Marking refund payment as paid
+    In order have consistent data on refund payments' status
+    As an Administrator
+    I want to mark refund payment as paid
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
+        And the store allows shipping with "Galaxy Post"
+        And the store allows paying with "Space money"
+        And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
+        And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And I am logged in as an administrator
+        And the order "#00000022" is already paid
+        And I want to refund some units of order "#00000022"
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+
+    Scenario: Marking refund payment as paid
+        Given I view the summary of the order "#00000022"
+        When I mark the first refund payment as "Paid"
+        Then I should see 1 refund payment with status "Paid"

--- a/features/marking_refund_payment_as_paid.feature
+++ b/features/marking_refund_payment_as_paid.feature
@@ -15,7 +15,7 @@ Feature: Marking refund payment as paid
         And I am logged in as an administrator
         And the order "#00000022" is already paid
         And I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
 
     Scenario: Marking refund payment as paid
         Given I view the summary of the order "#00000022"

--- a/features/marking_refund_payment_as_paid.feature
+++ b/features/marking_refund_payment_as_paid.feature
@@ -17,7 +17,8 @@ Feature: Marking refund payment as paid
         And I want to refund some units of order "#00000022"
         And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
 
+    @ui
     Scenario: Marking refund payment as paid
         Given I view the summary of the order "#00000022"
-        When I mark the first refund payment as "Paid"
-        Then I should see 1 refund payment with status "Paid"
+        When I complete the first refund payment
+        Then I should see 1 refund payment with status "Completed"

--- a/features/refunding_all_order_units.feature
+++ b/features/refunding_all_order_units.feature
@@ -18,7 +18,7 @@ Feature: Refunding all order units
     @ui @javascript
     Scenario: Refunding all order units
         When I want to refund some units of order "#00000022"
-        And I decide to refund all units of this order
+        And I decide to refund all units of this order with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$40.00"
         But I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"

--- a/features/refunding_order_shipping_cost.feature
+++ b/features/refunding_order_shipping_cost.feature
@@ -18,14 +18,14 @@ Feature: Refunding an order shipping cost
     @ui @application
     Scenario: Refunding an order shipment
         When I want to refund some units of order "#00000022"
-        And I decide to refund order shipment
+        And I decide to refund order shipment with "Space money" payment
         And this order refunded total should be "$20.00"
         And I should not be able to refund order shipment
 
     @ui @application
     Scenario: Refunding and order shipment along with order unit
         When I want to refund some units of order "#00000022"
-        And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund order shipment and 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$30.00"
         And I should not be able to refund order shipment

--- a/features/refunding_single_order_unit.feature
+++ b/features/refunding_single_order_unit.feature
@@ -62,7 +62,7 @@ Feature: Refunding a single order unit
         And the store allows paying with "Another offline payment method"
         When I want to refund some units of order "#00000022"
         Then I should be able to choose refund payment method
-        And there should be "Space Money" payment method
+        And there should be "Space money" payment method
         And there should be "Another offline payment method" payment method
 
     @application

--- a/features/refunding_single_order_unit.feature
+++ b/features/refunding_single_order_unit.feature
@@ -25,16 +25,16 @@ Feature: Refunding a single order unit
     Scenario: Refunding one of the order unit
         Given the order "#00000022" is already paid
         When I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$10.00"
         And I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"
-        But I should still be able to refund 2nd unit with product "Mr. Meeseeks T-Shirt"
+        But I should still be able to refund 2nd unit with product "Mr. Meeseeks T-Shirt" with "Space money" payment
 
     @application
     Scenario: Not being able to refund already refunded unit
         Given the order "#00000022" is already paid
-        And 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded
+        And 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded with "Space money" payment
         When I want to refund some units of order "#00000022"
         And I should not be able to refund 1st unit with product "Mr. Meeseeks T-Shirt"
 

--- a/features/refunding_single_order_unit.feature
+++ b/features/refunding_single_order_unit.feature
@@ -56,6 +56,15 @@ Feature: Refunding a single order unit
         When I view the summary of the order "#00000022"
         Then I should not be able to see refunds button
 
+    @ui
+    Scenario: Being able to choose refund payment method
+        Given the order "#00000022" is already paid
+        And the store allows paying with "Another offline payment method"
+        When I want to refund some units of order "#00000022"
+        Then I should be able to choose refund payment method
+        And there should be "Space Money" payment method
+        And there should be "Another offline payment method" payment method
+
     @application
     Scenario: Not being able to refund unit from an order that is unpaid
         When I want to refund some units of order "#00000022"

--- a/features/refunding_single_order_unit_with_promotion_applied.feature
+++ b/features/refunding_single_order_unit_with_promotion_applied.feature
@@ -20,6 +20,6 @@ Feature: Refunding a single order unit with promotion applied
     @ui @application
     Scenario: Refunding one of the order unit with discount applied
         When I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$9.00"

--- a/features/refunding_single_order_unit_with_taxes_applied.feature
+++ b/features/refunding_single_order_unit_with_taxes_applied.feature
@@ -21,6 +21,6 @@ Feature: Refunding a single order unit with taxes applied
     @ui @application
     Scenario: Refunding one of the order unit with tax applied
         When I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
         Then I should be notified that selected order units have been successfully refunded
         And this order refunded total should be "$11.00"

--- a/features/seeing_refund_payments_on_admin_order_view.feature
+++ b/features/seeing_refund_payments_on_admin_order_view.feature
@@ -1,0 +1,22 @@
+@refunds
+Feature: Seeing refund payments on admin order view
+    In order to see every payment related to user's credit memos
+    As an Administrator
+    I want to be able to browse them on order view
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
+        And the store allows shipping with "Galaxy Post"
+        And the store allows paying with "Space money"
+        And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
+        And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And I am logged in as an administrator
+        And the order "#00000022" is already paid
+        And I want to refund some units of order "#00000022"
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+
+    Scenario: Seeing refund payment on order view
+        When I view the summary of the order "#00000022"
+        Then I should see 1 refund payment with status "New"

--- a/features/seeing_refund_payments_on_admin_order_view.feature
+++ b/features/seeing_refund_payments_on_admin_order_view.feature
@@ -15,7 +15,7 @@ Feature: Seeing refund payments on admin order view
         And I am logged in as an administrator
         And the order "#00000022" is already paid
         And I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product
+        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
 
     Scenario: Seeing refund payment on order view
         When I view the summary of the order "#00000022"

--- a/features/seeing_refund_payments_on_admin_order_view.feature
+++ b/features/seeing_refund_payments_on_admin_order_view.feature
@@ -17,6 +17,7 @@ Feature: Seeing refund payments on admin order view
         And I want to refund some units of order "#00000022"
         And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
 
+    @ui
     Scenario: Seeing refund payment on order view
         When I view the summary of the order "#00000022"
         Then I should see 1 refund payment with status "New"

--- a/features/seeing_refund_payments_on_admin_order_view.feature
+++ b/features/seeing_refund_payments_on_admin_order_view.feature
@@ -14,8 +14,7 @@ Feature: Seeing refund payments on admin order view
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And I am logged in as an administrator
         And the order "#00000022" is already paid
-        And I want to refund some units of order "#00000022"
-        And I decide to refund 1st "Mr. Meeseeks T-Shirt" product with "Space money" payment
+        And I decided to refund 1st "Mr. Meeseeks T-Shirt" product of the order "00000022" with "Space money" payment
 
     @ui
     Scenario: Seeing refund payment on order view

--- a/migrations/Version20180817130113.php
+++ b/migrations/Version20180817130113.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20180817130113 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE sylius_refund_payment (id INT AUTO_INCREMENT NOT NULL, payment_method_id INT DEFAULT NULL, number VARCHAR(255) NOT NULL, order_number VARCHAR(255) NOT NULL, amount INT NOT NULL, currency_code VARCHAR(255) NOT NULL, state VARCHAR(255) NOT NULL, INDEX IDX_EFA5A4B25AA1164F (payment_method_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_refund_payment ADD CONSTRAINT FK_EFA5A4B25AA1164F FOREIGN KEY (payment_method_id) REFERENCES sylius_payment_method (id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE sylius_refund_payment');
+    }
+}

--- a/spec/Command/RefundUnitsSpec.php
+++ b/spec/Command/RefundUnitsSpec.php
@@ -10,10 +10,11 @@ final class RefundUnitsSpec extends ObjectBehavior
 {
     function it_represents_an_intention_to_refund_specific_order_units_and_shipments(): void
     {
-        $this->beConstructedWith('000222', [1, 3, 5], [2]);
+        $this->beConstructedWith('000222', [1, 3, 5], [2], 1);
 
         $this->orderNumber()->shouldReturn('000222');
         $this->unitIds()->shouldReturn([1, 3, 5]);
         $this->shipmentIds()->shouldReturn([2]);
+        $this->paymentMethodId()->shouldReturn(1);
     }
 }

--- a/spec/CommandHandler/RefundUnitsHandlerSpec.php
+++ b/spec/CommandHandler/RefundUnitsHandlerSpec.php
@@ -45,11 +45,12 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
                 $event->orderNumber() === '000222' &&
                 $event->unitIds() === [1, 3] &&
                 $event->shipmentIds() === [3, 4] &&
-                $event->amount() === 7000
+                $event->amount() === 7000 &&
+                $event->paymentMethodId() === 1
             ;
         }))->shouldBeCalled();
 
-        $this(new RefundUnits('000222', [1, 3], [3, 4]));
+        $this(new RefundUnits('000222', [1, 3], [3, 4], 1));
     }
 
     function it_changes_order_state_to_fully_refunded_when_whole_order_total_is_refunded(
@@ -67,11 +68,12 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
             return
                 $event->orderNumber() === '000222' &&
                 $event->unitIds() === [1, 3] &&
-                $event->amount() === 1500
+                $event->amount() === 1500 &&
+                $event->paymentMethodId() === 1
             ;
         }))->shouldBeCalled();
 
-        $this(new RefundUnits('000222', [1, 3], [3, 4]));
+        $this(new RefundUnits('000222', [1, 3], [3, 4], 1));
     }
 
     function it_throws_an_exception_if_order_is_not_available_for_refund(
@@ -81,7 +83,7 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(OrderNotAvailableForRefundingException::class)
-            ->during('__invoke', [new RefundUnits('000222', [1, 3], [3, 4])])
+            ->during('__invoke', [new RefundUnits('000222', [1, 3], [3, 4], 1)])
         ;
     }
 }

--- a/spec/CommandHandler/RefundUnitsHandlerSpec.php
+++ b/spec/CommandHandler/RefundUnitsHandlerSpec.php
@@ -7,6 +7,8 @@ namespace spec\Sylius\RefundPlugin\CommandHandler;
 use PhpSpec\ObjectBehavior;
 use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
@@ -19,13 +21,15 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
         RefunderInterface $orderItemUnitsRefunder,
         RefunderInterface $orderShipmentsRefunder,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
-        EventBus $eventBus
+        EventBus $eventBus,
+        OrderRepositoryInterface $orderRepository
     ): void {
         $this->beConstructedWith(
             $orderItemUnitsRefunder,
             $orderShipmentsRefunder,
             $orderRefundingAvailabilityChecker,
-            $eventBus
+            $eventBus,
+            $orderRepository
         );
     }
 
@@ -33,12 +37,17 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
         RefunderInterface $orderItemUnitsRefunder,
         RefunderInterface $orderShipmentsRefunder,
-        EventBus $eventBus
+        EventBus $eventBus,
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order
     ): void {
         $orderRefundingAvailabilityChecker->__invoke('000222')->willReturn(true);
 
         $orderItemUnitsRefunder->refundFromOrder([1, 3], '000222')->willReturn(3000);
         $orderShipmentsRefunder->refundFromOrder([3, 4], '000222')->willReturn(4000);
+
+        $orderRepository->findOneByNumber('000222')->willReturn($order);
+        $order->getCurrencyCode()->willReturn('USD');
 
         $eventBus->dispatch(Argument::that(function (UnitsRefunded $event): bool {
             return
@@ -57,12 +66,17 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
         RefunderInterface $orderItemUnitsRefunder,
         RefunderInterface $orderShipmentsRefunder,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
-        EventBus $eventBus
+        EventBus $eventBus,
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order
     ): void {
         $orderRefundingAvailabilityChecker->__invoke('000222')->willReturn(true);
 
         $orderItemUnitsRefunder->refundFromOrder([1, 3], '000222')->willReturn(1000);
         $orderShipmentsRefunder->refundFromOrder([3, 4], '000222')->willReturn(500);
+
+        $orderRepository->findOneByNumber('000222')->willReturn($order);
+        $order->getCurrencyCode()->willReturn('USD');
 
         $eventBus->dispatch(Argument::that(function (UnitsRefunded $event): bool {
             return

--- a/spec/Entity/RefundPaymentSpec.php
+++ b/spec/Entity/RefundPaymentSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Entity;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\RefundPlugin\Entity\RefundPayment;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+final class RefundPaymentSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith('000001', 100, 'USD', RefundPaymentInterface::STATE_NEW);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RefundPayment::class);
+    }
+
+    function it_impleents_refund_payment_interface(): void
+    {
+        $this->shouldImplement(RefundPaymentInterface::class);
+    }
+
+    function it_has_number(): void
+    {
+        $this->getNumber()->shouldReturn('000001');
+    }
+
+    function it_has_amount(): void
+    {
+        $this->getAmount()->shouldReturn(100);
+    }
+
+    function it_has_currency_code(): void
+    {
+        $this->getCurrencyCode()->shouldReturn('USD');
+    }
+
+    function it_has_state(): void
+    {
+        $this->getState()->shouldReturn(RefundPaymentInterface::STATE_NEW);
+    }
+}

--- a/spec/Entity/RefundPaymentSpec.php
+++ b/spec/Entity/RefundPaymentSpec.php
@@ -13,7 +13,7 @@ final class RefundPaymentSpec extends ObjectBehavior
 {
     function let(PaymentMethodInterface $paymentMethod): void
     {
-        $this->beConstructedWith('000001', 100, 'USD', RefundPaymentInterface::STATE_NEW, $paymentMethod);
+        $this->beConstructedWith('000001', '000002', 100, 'USD', RefundPaymentInterface::STATE_NEW, $paymentMethod);
     }
 
     function it_is_initializable(): void
@@ -29,6 +29,11 @@ final class RefundPaymentSpec extends ObjectBehavior
     function it_has_number(): void
     {
         $this->getNumber()->shouldReturn('000001');
+    }
+
+    function it_has_order_number(): void
+    {
+        $this->getOrderNumber()->shouldReturn('000002');
     }
 
     function it_has_amount(): void

--- a/spec/Entity/RefundPaymentSpec.php
+++ b/spec/Entity/RefundPaymentSpec.php
@@ -21,7 +21,7 @@ final class RefundPaymentSpec extends ObjectBehavior
         $this->shouldHaveType(RefundPayment::class);
     }
 
-    function it_impleents_refund_payment_interface(): void
+    function it_implements_refund_payment_interface(): void
     {
         $this->shouldImplement(RefundPaymentInterface::class);
     }

--- a/spec/Entity/RefundPaymentSpec.php
+++ b/spec/Entity/RefundPaymentSpec.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace spec\Sylius\RefundPlugin\Entity;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\RefundPlugin\Entity\RefundPayment;
 use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
 
 final class RefundPaymentSpec extends ObjectBehavior
 {
-    function let(): void
+    function let(PaymentMethodInterface $paymentMethod): void
     {
-        $this->beConstructedWith('000001', 100, 'USD', RefundPaymentInterface::STATE_NEW);
+        $this->beConstructedWith('000001', 100, 'USD', RefundPaymentInterface::STATE_NEW, $paymentMethod);
     }
 
     function it_is_initializable(): void
@@ -43,5 +44,10 @@ final class RefundPaymentSpec extends ObjectBehavior
     function it_has_state(): void
     {
         $this->getState()->shouldReturn(RefundPaymentInterface::STATE_NEW);
+    }
+
+    function it_has_payment_method(): void
+    {
+        $this->getPaymentMethod()->shouldBeAnInstanceOf(PaymentMethodInterface::class);
     }
 }

--- a/spec/Event/UnitsRefundedSpec.php
+++ b/spec/Event/UnitsRefundedSpec.php
@@ -10,11 +10,12 @@ final class UnitsRefundedSpec extends ObjectBehavior
 {
     function it_represents_an_immutable_fact_that_units_and_shipments_has_been_refunded(): void
     {
-        $this->beConstructedWith('000222', [1, 2, 3], [1], 5000);
+        $this->beConstructedWith('000222', [1, 2, 3], [1], 1, 5000);
 
         $this->orderNumber()->shouldReturn('000222');
         $this->unitIds()->shouldReturn([1, 2, 3]);
         $this->shipmentIds()->shouldReturn([1]);
+        $this->paymentMethodId()->shouldReturn(1);
         $this->amount()->shouldReturn(5000);
     }
 }

--- a/spec/Event/UnitsRefundedSpec.php
+++ b/spec/Event/UnitsRefundedSpec.php
@@ -10,12 +10,13 @@ final class UnitsRefundedSpec extends ObjectBehavior
 {
     function it_represents_an_immutable_fact_that_units_and_shipments_has_been_refunded(): void
     {
-        $this->beConstructedWith('000222', [1, 2, 3], [1], 1, 5000);
+        $this->beConstructedWith('000222', [1, 2, 3], [1], 1, 5000, 'USD');
 
         $this->orderNumber()->shouldReturn('000222');
         $this->unitIds()->shouldReturn([1, 2, 3]);
         $this->shipmentIds()->shouldReturn([1]);
         $this->paymentMethodId()->shouldReturn(1);
         $this->amount()->shouldReturn(5000);
+        $this->currencyCode()->shouldReturn('USD');
     }
 }

--- a/spec/Factory/RefundPaymentFactorySpec.php
+++ b/spec/Factory/RefundPaymentFactorySpec.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPayment;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\Factory\RefundPaymentFactory;
+use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
+
+final class RefundPaymentFactorySpec extends ObjectBehavior
+{
+    function let(PaymentMethodRepositoryInterface $paymentMethodRepository): void
+    {
+        $this->beConstructedWith($paymentMethodRepository);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RefundPaymentFactory::class);
+    }
+
+    function it_implements_refund_payment_factory_interface(): void
+    {
+        $this->shouldImplement(RefundPaymentFactoryInterface::class);
+    }
+
+    function it_creates_new_refund_payment(
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        PaymentMethodInterface $paymentMethod
+    ): void {
+        $paymentMethodRepository->find(1)->willReturn($paymentMethod);
+
+        $this->createWithData(
+            '0001',
+            '0002',
+            1000,
+            'USD',
+            RefundPaymentInterface::STATE_NEW,
+            1
+        )->shouldBeLike(new RefundPayment(
+            '0001',
+            '0002',
+            1000,
+            'USD',
+            RefundPaymentInterface::STATE_NEW,
+            $paymentMethod->getWrappedObject())
+        );
+    }
+}

--- a/spec/Listener/UnitsRefundedEventListenerSpec.php
+++ b/spec/Listener/UnitsRefundedEventListenerSpec.php
@@ -28,6 +28,6 @@ final class UnitsRefundedEventListenerSpec extends ObjectBehavior
 
         $orderFullyRefundedStateResolver->resolve('000222')->shouldBeCalled();
 
-        $this(new UnitsRefunded('000222', [1, 2], [1], 1000));
+        $this(new UnitsRefunded('000222', [1, 2], [1], 1, 1000));
     }
 }

--- a/spec/Listener/UnitsRefundedEventListenerSpec.php
+++ b/spec/Listener/UnitsRefundedEventListenerSpec.php
@@ -41,22 +41,24 @@ final class UnitsRefundedEventListenerSpec extends ObjectBehavior
         EntityManagerInterface $entityManager,
         RefundPaymentInterface $refundPayment
     ): void {
-        $session->getFlashBag()->willReturn($flashBag);
-
-        $flashBag->add('success', 'sylius_refund.units_successfully_refunded')->shouldBeCalled();
-
-        $orderFullyRefundedStateResolver->resolve('000222')->shouldBeCalled();
-
         $numberGenerator->generate()->willReturn('0000001');
 
         $refundPaymentFactory->createWithData(
             '0000001',
+            '000222',
             1000,
             'USD',
             RefundPaymentInterface::STATE_NEW, 1
         )->willReturn($refundPayment);
 
         $entityManager->persist($refundPayment)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
+
+        $orderFullyRefundedStateResolver->resolve('000222')->shouldBeCalled();
+
+        $session->getFlashBag()->willReturn($flashBag);
+
+        $flashBag->add('success', 'sylius_refund.units_successfully_refunded')->shouldBeCalled();
 
         $this(new UnitsRefunded('000222', [1, 2], [1], 1, 1000, 'USD'));
     }

--- a/spec/ProcessManager/CreditMemoProcessManagerSpec.php
+++ b/spec/ProcessManager/CreditMemoProcessManagerSpec.php
@@ -28,6 +28,6 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
             ;
         }));
 
-        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 1, 3000));
+        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 1, 3000, 'USDs'));
     }
 }

--- a/spec/ProcessManager/CreditMemoProcessManagerSpec.php
+++ b/spec/ProcessManager/CreditMemoProcessManagerSpec.php
@@ -28,6 +28,6 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
             ;
         }));
 
-        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 1, 3000, 'USDs'));
+        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 1, 3000, 'USD'));
     }
 }

--- a/spec/ProcessManager/CreditMemoProcessManagerSpec.php
+++ b/spec/ProcessManager/CreditMemoProcessManagerSpec.php
@@ -28,6 +28,6 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
             ;
         }));
 
-        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 3000));
+        $this(new UnitsRefunded('000222', [1, 2, 3], [1, 2], 1, 3000));
     }
 }

--- a/spec/StateResolver/RefundPaymentCompletedStateApplierSpec.php
+++ b/spec/StateResolver/RefundPaymentCompletedStateApplierSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\StateResolver;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use SM\StateMachine\StateMachineInterface;
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplier;
+use Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplierInterface;
+use Sylius\RefundPlugin\StateResolver\RefundPaymentTransitions;
+
+final class RefundPaymentCompletedStateApplierSpec extends ObjectBehavior
+{
+    function let(StateMachineFactoryInterface $stateMachineFactory, ObjectManager $refundPaymentManager): void
+    {
+        $this->beConstructedWith($stateMachineFactory, $refundPaymentManager);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(RefundPaymentCompletedStateApplier::class);
+    }
+
+    function it_implements_refund_payment_completed_state_applier_interface(): void
+    {
+        $this->shouldImplement(RefundPaymentCompletedStateApplierInterface::class);
+    }
+
+    function it_applies_complete_transition_on_refund_payment(
+        StateMachineFactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine,
+        ObjectManager $refundPaymentManager,
+        RefundPaymentInterface $refundPayment
+    ): void {
+        $stateMachineFactory->get($refundPayment, RefundPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->apply(RefundPaymentTransitions::TRANSITION_COMPLETE)->shouldBeCalled();
+
+        $refundPaymentManager->flush()->shouldBeCalled();
+
+        $this->apply($refundPayment);
+    }
+}

--- a/src/Action/Admin/OrderRefundsListAction.php
+++ b/src/Action/Admin/OrderRefundsListAction.php
@@ -6,6 +6,7 @@ namespace Sylius\RefundPlugin\Action\Admin;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,13 +26,18 @@ final class OrderRefundsListAction
     /** @var Environment */
     private $twig;
 
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
         Environment $twig
     ) {
         $this->orderRepository = $orderRepository;
         $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
+        $this->paymentMethodRepository = $paymentMethodRepository;
         $this->twig = $twig;
     }
 
@@ -44,8 +50,13 @@ final class OrderRefundsListAction
         /** @var OrderInterface $order */
         $order = $this->orderRepository->findOneByNumber($request->attributes->get('orderNumber'));
 
+        $paymentMethods = $this->paymentMethodRepository->findAll();
+
         return new Response(
-            $this->twig->render('@SyliusRefundPlugin/orderRefunds.html.twig', ['order' => $order])
+            $this->twig->render('@SyliusRefundPlugin/orderRefunds.html.twig', [
+                'order' => $order,
+                'payment_methods' => $paymentMethods
+            ])
         );
     }
 

--- a/src/Action/Admin/OrderRefundsListAction.php
+++ b/src/Action/Admin/OrderRefundsListAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Action\Admin;
 
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
@@ -23,22 +25,27 @@ final class OrderRefundsListAction
     /** @var OrderRefundingAvailabilityCheckerInterface */
     private $orderRefundingAvailabilityChecker;
 
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
     /** @var Environment */
     private $twig;
 
-    /** @var PaymentMethodRepositoryInterface */
-    private $paymentMethodRepository;
+    /** @var ChannelContextInterface */
+    private $channelContext;
 
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
         PaymentMethodRepositoryInterface $paymentMethodRepository,
-        Environment $twig
+        Environment $twig,
+        ChannelContextInterface $channelContext
     ) {
         $this->orderRepository = $orderRepository;
         $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
         $this->paymentMethodRepository = $paymentMethodRepository;
         $this->twig = $twig;
+        $this->channelContext = $channelContext;
     }
 
     public function __invoke(Request $request): Response
@@ -50,7 +57,9 @@ final class OrderRefundsListAction
         /** @var OrderInterface $order */
         $order = $this->orderRepository->findOneByNumber($request->attributes->get('orderNumber'));
 
-        $paymentMethods = $this->paymentMethodRepository->findAll();
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelContext->getChannel();
+        $paymentMethods = $this->paymentMethodRepository->findEnabledForChannel($channel);
 
         return new Response(
             $this->twig->render('@SyliusRefundPlugin/orderRefunds.html.twig', [

--- a/src/Action/CompleteRefundPaymentAction.php
+++ b/src/Action/CompleteRefundPaymentAction.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Action;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
 use Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplierInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\RouterInterface;
 
 final class CompleteRefundPaymentAction
 {
@@ -22,25 +26,40 @@ final class CompleteRefundPaymentAction
     /** @var RefundPaymentCompletedStateApplierInterface */
     private $refundPaymentCompletedStateApplier;
 
+    /** @var RouterInterface */
+    private $router;
+
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
     public function __construct(
         Session $session,
         ObjectRepository $refundPaymentInterface,
-        RefundPaymentCompletedStateApplierInterface $refundPaymentCompletedStateApplier
+        RefundPaymentCompletedStateApplierInterface $refundPaymentCompletedStateApplier,
+        RouterInterface $router,
+        OrderRepositoryInterface $orderRepository
     ) {
         $this->session = $session;
         $this->refundPaymentRepository = $refundPaymentInterface;
         $this->refundPaymentCompletedStateApplier = $refundPaymentCompletedStateApplier;
+        $this->router = $router;
+        $this->orderRepository = $orderRepository;
     }
 
-    public function __invoke(Request $request, string $id): Response
+    public function __invoke(Request $request, string $orderNumber, string $id): Response
     {
         /** @var RefundPaymentInterface $refundPayment */
         $refundPayment = $this->refundPaymentRepository->find($id);
 
         $this->refundPaymentCompletedStateApplier->apply($refundPayment);
 
-        $this->session->getFlashBag()->add('sucess', 'sylius_refund.refund_payment_completed');
+        $this->session->getFlashBag()->add('success', 'sylius_refund.refund_payment_completed');
 
-        return new Response('', Response::HTTP_OK);
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneByNumber($orderNumber);
+
+        return new RedirectResponse($this->router->generate(
+            'sylius_admin_order_show',
+            ['id' => $order->getId()]));
     }
 }

--- a/src/Action/CompleteRefundPaymentAction.php
+++ b/src/Action/CompleteRefundPaymentAction.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Action;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CompleteRefundPaymentAction
+{
+    public function __invoke(Request $request, string $orderNumber, string $refundPaymentId): Response
+    {
+        // TODO: Implement __invoke() method.
+    }
+}

--- a/src/Action/CompleteRefundPaymentAction.php
+++ b/src/Action/CompleteRefundPaymentAction.php
@@ -4,13 +4,43 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Action;
 
+use Doctrine\Common\Persistence\ObjectRepository;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplierInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 final class CompleteRefundPaymentAction
 {
-    public function __invoke(Request $request, string $orderNumber, string $refundPaymentId): Response
+    /** @var Session */
+    private $session;
+
+    /** @var ObjectRepository */
+    private $refundPaymentRepository;
+
+    /** @var RefundPaymentCompletedStateApplierInterface */
+    private $refundPaymentCompletedStateApplier;
+
+    public function __construct(
+        Session $session,
+        ObjectRepository $refundPaymentInterface,
+        RefundPaymentCompletedStateApplierInterface $refundPaymentCompletedStateApplier
+    ) {
+        $this->session = $session;
+        $this->refundPaymentRepository = $refundPaymentInterface;
+        $this->refundPaymentCompletedStateApplier = $refundPaymentCompletedStateApplier;
+    }
+
+    public function __invoke(Request $request, string $id): Response
     {
-        // TODO: Implement __invoke() method.
+        /** @var RefundPaymentInterface $refundPayment */
+        $refundPayment = $this->refundPaymentRepository->find($id);
+
+        $this->refundPaymentCompletedStateApplier->apply($refundPayment);
+
+        $this->session->getFlashBag()->add('sucess', 'sylius_refund.refund_payment_completed');
+
+        return new Response('', Response::HTTP_OK);
     }
 }

--- a/src/Action/CompleteRefundPaymentAction.php
+++ b/src/Action/CompleteRefundPaymentAction.php
@@ -35,9 +35,9 @@ final class CompleteRefundPaymentAction
     public function __construct(
         Session $session,
         ObjectRepository $refundPaymentInterface,
+        OrderRepositoryInterface $orderRepository,
         RefundPaymentCompletedStateApplierInterface $refundPaymentCompletedStateApplier,
-        RouterInterface $router,
-        OrderRepositoryInterface $orderRepository
+        RouterInterface $router
     ) {
         $this->session = $session;
         $this->refundPaymentRepository = $refundPaymentInterface;

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -11,13 +11,14 @@ final class RefundUnits extends Command
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds)
+    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, int $paymentMethodId)
     {
         $this->init();
         $this->setPayload([
             'order_number' => $orderNumber,
             'unit_ids' => $unitIds,
             'shipment_ids' => $shipmentIds,
+            'payment_method_id' => $paymentMethodId,
         ]);
     }
 
@@ -34,5 +35,10 @@ final class RefundUnits extends Command
     public function shipmentIds(): array
     {
         return $this->payload()['shipment_ids'];
+    }
+
+    public function paymentMethodId(): int
+    {
+        return $this->payload()['payment_method_id'];
     }
 }

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -11,7 +11,7 @@ final class RefundUnits extends Command
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, int $paymentMethodId)
+    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, string $paymentMethodId)
     {
         $this->init();
         $this->setPayload([
@@ -37,7 +37,7 @@ final class RefundUnits extends Command
         return $this->payload()['shipment_ids'];
     }
 
-    public function paymentMethodId(): int
+    public function paymentMethodId(): string
     {
         return $this->payload()['payment_method_id'];
     }

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -11,7 +11,7 @@ final class RefundUnits extends Command
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, string $paymentMethodId)
+    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, int $paymentMethodId)
     {
         $this->init();
         $this->setPayload([
@@ -37,7 +37,7 @@ final class RefundUnits extends Command
         return $this->payload()['shipment_ids'];
     }
 
-    public function paymentMethodId(): string
+    public function paymentMethodId(): int
     {
         return $this->payload()['payment_method_id'];
     }

--- a/src/CommandHandler/RefundUnitsHandler.php
+++ b/src/CommandHandler/RefundUnitsHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\CommandHandler;
 
 use Prooph\ServiceBus\EventBus;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
@@ -51,7 +52,8 @@ final class RefundUnitsHandler
 
         $orderNumber = $command->orderNumber();
 
-        $currencyCode = $this->orderRepository->findOneByNumber($orderNumber)->getCurrencyCode();
+        /** @var OrderInterface $order */
+        $order = $this->orderRepository->findOneByNumber($orderNumber);
 
         $refundedTotal = 0;
         $refundedTotal += $this->orderUnitsRefunder->refundFromOrder($command->unitIds(), $orderNumber);
@@ -63,7 +65,7 @@ final class RefundUnitsHandler
             $command->shipmentIds(),
             $command->paymentMethodId(),
             $refundedTotal,
-            $currencyCode
+            $order->getCurrencyCode()
         ));
     }
 }

--- a/src/CommandHandler/RefundUnitsHandler.php
+++ b/src/CommandHandler/RefundUnitsHandler.php
@@ -53,6 +53,7 @@ final class RefundUnitsHandler
             $orderNumber,
             $command->unitIds(),
             $command->shipmentIds(),
+            $command->paymentMethodId(),
             $refundedTotal
         ));
     }

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -70,6 +70,11 @@ class RefundPayment implements RefundPaymentInterface
         return $this->state;
     }
 
+    public function setState(string $state): void
+    {
+        $this->state = $state;
+    }
+
     public function getId(): int
     {
         return $this->id;

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -15,6 +15,7 @@ class RefundPayment implements RefundPaymentInterface
     /** @var string */
     private $number;
 
+    /** @var string */
     private $orderNumber;
 
     /** @var int */

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Entity;
+
+/** @final */
+class RefundPayment implements RefundPaymentInterface
+{
+    /** @var int */
+    private $id;
+
+    /** @var string */
+    private $number;
+
+    /** @var int */
+    private $amount;
+
+    /** @var string */
+    private $currencyCode;
+
+    /** @var string */
+    private $state;
+
+    public function __construct(
+        string $number,
+        int $amount,
+        string $currencyCode,
+        string $state
+    ) {
+        $this->number = $number;
+        $this->amount = $amount;
+        $this->currencyCode = $currencyCode;
+        $this->state = $state;
+    }
+
+    public function getNumber(): string
+    {
+        return $this->number;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function getCurrencyCode(): string
+    {
+        return $this->currencyCode;
+    }
+
+    public function getState(): string
+    {
+        return $this->state;
+    }
+}

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Entity;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
 
 /** @final */
 class RefundPayment implements RefundPaymentInterface
@@ -22,16 +23,21 @@ class RefundPayment implements RefundPaymentInterface
     /** @var string */
     private $state;
 
+    /** @var PaymentMethodInterface */
+    private $paymentMethod;
+
     public function __construct(
         string $number,
         int $amount,
         string $currencyCode,
-        string $state
+        string $state,
+        PaymentMethodInterface $paymentMethod
     ) {
         $this->number = $number;
         $this->amount = $amount;
         $this->currencyCode = $currencyCode;
         $this->state = $state;
+        $this->paymentMethod = $paymentMethod;
     }
 
     public function getNumber(): string
@@ -52,5 +58,15 @@ class RefundPayment implements RefundPaymentInterface
     public function getState(): string
     {
         return $this->state;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getPaymentMethod(): PaymentMethodInterface
+    {
+        return $this->paymentMethod;
     }
 }

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Entity;
+
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 
 /** @final */
@@ -13,6 +14,8 @@ class RefundPayment implements RefundPaymentInterface
 
     /** @var string */
     private $number;
+
+    private $orderNumber;
 
     /** @var int */
     private $amount;
@@ -28,12 +31,14 @@ class RefundPayment implements RefundPaymentInterface
 
     public function __construct(
         string $number,
+        string $orderNumber,
         int $amount,
         string $currencyCode,
         string $state,
         PaymentMethodInterface $paymentMethod
     ) {
         $this->number = $number;
+        $this->orderNumber = $orderNumber;
         $this->amount = $amount;
         $this->currencyCode = $currencyCode;
         $this->state = $state;
@@ -43,6 +48,11 @@ class RefundPayment implements RefundPaymentInterface
     public function getNumber(): string
     {
         return $this->number;
+    }
+
+    public function getOrderNumber(): string
+    {
+        return $this->orderNumber;
     }
 
     public function getAmount(): int

--- a/src/Entity/RefundPaymentInterface.php
+++ b/src/Entity/RefundPaymentInterface.php
@@ -10,7 +10,7 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 interface RefundPaymentInterface extends ResourceInterface
 {
     public const STATE_NEW = 'New';
-    public const STATE_PAID = 'Paid';
+    public const STATE_COMPLETED = 'Completed';
 
     public function getNumber(): string;
 

--- a/src/Entity/RefundPaymentInterface.php
+++ b/src/Entity/RefundPaymentInterface.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Entity;
 
-interface RefundPaymentInterface
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+interface RefundPaymentInterface extends ResourceInterface
 {
     public const STATE_NEW = 'New';
     public const STATE_PAID = 'Paid';
@@ -16,4 +19,6 @@ interface RefundPaymentInterface
     public function getCurrencyCode(): string;
 
     public function getState(): string;
+
+    public function getPaymentMethod(): PaymentMethodInterface;
 }

--- a/src/Entity/RefundPaymentInterface.php
+++ b/src/Entity/RefundPaymentInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Entity;
+
+interface RefundPaymentInterface
+{
+    public const STATE_NEW = 'New';
+    public const STATE_PAID = 'Paid';
+
+    public function getNumber(): string;
+
+    public function getAmount(): int;
+
+    public function getCurrencyCode(): string;
+
+    public function getState(): string;
+}

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -15,7 +15,7 @@ final class UnitsRefunded extends DomainEvent
         string $orderNumber,
         array $unitIds,
         array $shipmentIds,
-        int $paymentMethodId,
+        string $paymentMethodId,
         int $amount,
         string $currencyCode
     ) {
@@ -50,7 +50,7 @@ final class UnitsRefunded extends DomainEvent
         return $this->payload['amount'];
     }
 
-    public function paymentMethodId(): int
+    public function paymentMethodId(): string
     {
         return $this->payload['payment_method_id'];
     }

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -11,14 +11,20 @@ final class UnitsRefunded extends DomainEvent
 {
     use PayloadTrait;
 
-    public function __construct(string $orderNumber, array $unitIds, array $shipmentIds, int $amount)
-    {
+    public function __construct(
+        string $orderNumber,
+        array $unitIds,
+        array $shipmentIds,
+        int $paymentMethodId,
+        int $amount
+    ) {
         $this->init();
         $this->setPayload([
             'order_number' => $orderNumber,
             'unit_ids' => $unitIds,
             'shipment_ids' => $shipmentIds,
             'amount' => $amount,
+            'payment_method_id' => $paymentMethodId,
         ]);
     }
 
@@ -40,5 +46,10 @@ final class UnitsRefunded extends DomainEvent
     public function amount(): int
     {
         return $this->payload['amount'];
+    }
+
+    public function paymentMethodId(): int
+    {
+        return $this->payload['payment_method_id'];
     }
 }

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -15,7 +15,7 @@ final class UnitsRefunded extends DomainEvent
         string $orderNumber,
         array $unitIds,
         array $shipmentIds,
-        string $paymentMethodId,
+        int $paymentMethodId,
         int $amount,
         string $currencyCode
     ) {
@@ -50,7 +50,7 @@ final class UnitsRefunded extends DomainEvent
         return $this->payload['amount'];
     }
 
-    public function paymentMethodId(): string
+    public function paymentMethodId(): int
     {
         return $this->payload['payment_method_id'];
     }

--- a/src/Event/UnitsRefunded.php
+++ b/src/Event/UnitsRefunded.php
@@ -16,7 +16,8 @@ final class UnitsRefunded extends DomainEvent
         array $unitIds,
         array $shipmentIds,
         int $paymentMethodId,
-        int $amount
+        int $amount,
+        string $currencyCode
     ) {
         $this->init();
         $this->setPayload([
@@ -24,6 +25,7 @@ final class UnitsRefunded extends DomainEvent
             'unit_ids' => $unitIds,
             'shipment_ids' => $shipmentIds,
             'amount' => $amount,
+            'currency_code' => $currencyCode,
             'payment_method_id' => $paymentMethodId,
         ]);
     }
@@ -51,5 +53,10 @@ final class UnitsRefunded extends DomainEvent
     public function paymentMethodId(): int
     {
         return $this->payload['payment_method_id'];
+    }
+
+    public function currencyCode(): string
+    {
+        return $this->payload['currency_code'];
     }
 }

--- a/src/Factory/RefundPaymentFactory.php
+++ b/src/Factory/RefundPaymentFactory.php
@@ -25,7 +25,7 @@ final class RefundPaymentFactory implements RefundPaymentFactoryInterface
         int $amount,
         string $currencyCode,
         string $state,
-        string $paymentMethodId
+        int $paymentMethodId
     ): RefundPaymentInterface {
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $this->paymentMethodRepository->find($paymentMethodId);

--- a/src/Factory/RefundPaymentFactory.php
+++ b/src/Factory/RefundPaymentFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Factory;
+
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPayment;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+final class RefundPaymentFactory implements RefundPaymentFactoryInterface
+{
+    /** @var PaymentMethodRepositoryInterface */
+    private $paymentMethodRepository;
+
+    public function __construct(PaymentMethodRepositoryInterface $paymentMethodRepository)
+    {
+        $this->paymentMethodRepository = $paymentMethodRepository;
+    }
+
+    public function createWithData(
+        string $number,
+        int $amount,
+        string $currencyCode,
+        string $state,
+        int $paymentMethodId
+    ): RefundPaymentInterface {
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $this->paymentMethodRepository->find($paymentMethodId);
+
+        return new RefundPayment($number, $amount, $currencyCode, $state, $paymentMethod);
+    }
+}

--- a/src/Factory/RefundPaymentFactory.php
+++ b/src/Factory/RefundPaymentFactory.php
@@ -21,14 +21,15 @@ final class RefundPaymentFactory implements RefundPaymentFactoryInterface
 
     public function createWithData(
         string $number,
+        string $orderNumber,
         int $amount,
         string $currencyCode,
         string $state,
-        int $paymentMethodId
+        string $paymentMethodId
     ): RefundPaymentInterface {
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $this->paymentMethodRepository->find($paymentMethodId);
 
-        return new RefundPayment($number, $amount, $currencyCode, $state, $paymentMethod);
+        return new RefundPayment($number, $orderNumber, $amount, $currencyCode, $state, $paymentMethod);
     }
 }

--- a/src/Factory/RefundPaymentFactoryInterface.php
+++ b/src/Factory/RefundPaymentFactoryInterface.php
@@ -10,9 +10,10 @@ interface RefundPaymentFactoryInterface
 {
     public function createWithData(
         string $number,
+        string $orderNumber,
         int $amount,
         string $currencyCode,
         string $state,
-        int $paymentMethodId
+        string $paymentMethodId
     ): RefundPaymentInterface;
 }

--- a/src/Factory/RefundPaymentFactoryInterface.php
+++ b/src/Factory/RefundPaymentFactoryInterface.php
@@ -14,6 +14,6 @@ interface RefundPaymentFactoryInterface
         int $amount,
         string $currencyCode,
         string $state,
-        string $paymentMethodId
+        int $paymentMethodId
     ): RefundPaymentInterface;
 }

--- a/src/Factory/RefundPaymentFactoryInterface.php
+++ b/src/Factory/RefundPaymentFactoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Factory;
+
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+interface RefundPaymentFactoryInterface
+{
+    public function createWithData(
+        string $number,
+        int $amount,
+        string $currencyCode,
+        string $state,
+        int $paymentMethodId
+    ): RefundPaymentInterface;
+}

--- a/src/Listener/UnitsRefundedEventListener.php
+++ b/src/Listener/UnitsRefundedEventListener.php
@@ -47,6 +47,7 @@ final class UnitsRefundedEventListener
     {
         $refundPayment = $this->refundPaymentFactory->createWithData(
             $this->numberGenerator->generate(),
+            $event->orderNumber(),
             $event->amount(),
             $event->currencyCode(),
             RefundPaymentInterface::STATE_NEW,

--- a/src/Listener/UnitsRefundedEventListener.php
+++ b/src/Listener/UnitsRefundedEventListener.php
@@ -55,6 +55,7 @@ final class UnitsRefundedEventListener
         );
 
         $this->entityManager->persist($refundPayment);
+        $this->entityManager->flush();
 
         $this->orderFullyRefundedStateResolver->resolve($event->orderNumber());
         $this->session->getFlashBag()->add('success', 'sylius_refund.units_successfully_refunded');

--- a/src/Listener/UnitsRefundedEventListener.php
+++ b/src/Listener/UnitsRefundedEventListener.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Listener;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
+use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
+use Sylius\RefundPlugin\Generator\NumberGenerator;
 use Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolverInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -16,16 +20,41 @@ final class UnitsRefundedEventListener
     /** @var OrderFullyRefundedStateResolverInterface */
     private $orderFullyRefundedStateResolver;
 
+    /** @var NumberGenerator */
+    private $numberGenerator;
+
+    /** @var RefundPaymentFactoryInterface */
+    private $refundPaymentFactory;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
     public function __construct(
         Session $session,
-        OrderFullyRefundedStateResolverInterface $orderFullyRefundedStateResolver
+        OrderFullyRefundedStateResolverInterface $orderFullyRefundedStateResolver,
+        NumberGenerator $numberGenerator,
+        RefundPaymentFactoryInterface $refundPaymentFactory,
+        EntityManagerInterface $entityManager
     ) {
         $this->session = $session;
         $this->orderFullyRefundedStateResolver = $orderFullyRefundedStateResolver;
+        $this->numberGenerator = $numberGenerator;
+        $this->refundPaymentFactory = $refundPaymentFactory;
+        $this->entityManager = $entityManager;
     }
 
     public function __invoke(UnitsRefunded $event): void
     {
+        $refundPayment = $this->refundPaymentFactory->createWithData(
+            $this->numberGenerator->generate(),
+            $event->amount(),
+            $event->currencyCode(),
+            RefundPaymentInterface::STATE_NEW,
+            $event->paymentMethodId()
+        );
+
+        $this->entityManager->persist($refundPayment);
+
         $this->orderFullyRefundedStateResolver->resolve($event->orderNumber());
         $this->session->getFlashBag()->add('success', 'sylius_refund.units_successfully_refunded');
     }

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -19,7 +19,7 @@ final class RefundUnitsRequest
             $request->attributes->get('orderNumber'),
             self::parseIdsToIntegers($request->request->get('sylius_refund_units', [])),
             self::parseIdsToIntegers($request->request->get('sylius_refund_shipments', [])),
-            $request->request->get('sylius_refund_payment_method')
+            (int) $request->request->get('sylius_refund_payment_method')
         );
     }
 

--- a/src/Request/RefundUnitsRequest.php
+++ b/src/Request/RefundUnitsRequest.php
@@ -18,7 +18,8 @@ final class RefundUnitsRequest
         return new RefundUnits(
             $request->attributes->get('orderNumber'),
             self::parseIdsToIntegers($request->request->get('sylius_refund_units', [])),
-            self::parseIdsToIntegers($request->request->get('sylius_refund_shipments', []))
+            self::parseIdsToIntegers($request->request->get('sylius_refund_shipments', [])),
+            $request->request->get('sylius_refund_payment_method')
         );
     }
 

--- a/src/Resources/config/admin_routing.yml
+++ b/src/Resources/config/admin_routing.yml
@@ -50,3 +50,19 @@ sylius_refund_admin_credit_memo_download:
     methods: [GET]
     defaults:
         _controller: Sylius\RefundPlugin\Action\Admin\DownloadCreditMemoAction
+
+sylius_refund_order_refund_payment_list:
+    path: /orders/{orderNumber}/refund-payments
+    methods: [GET]
+    defaults:
+        _controller: sylius_refund.controller.refund_payment:indexAction
+        _sylius:
+            criteria:
+                orderNumber: $orderNumber
+            template: "@SyliusRefundPlugin/Order/Admin/CreditMemo/list.html.twig"
+
+sylius_refund_complete_refund_payment:
+    path: /orders/{orderNumber}/refund-payments/{id}/complete
+    methods: [POST]
+    defaults:
+        _controller: Sylius\RefundPlugin\Action\CompleteRefundPaymentAction

--- a/src/Resources/config/admin_routing.yml
+++ b/src/Resources/config/admin_routing.yml
@@ -57,9 +57,9 @@ sylius_refund_order_refund_payment_list:
     defaults:
         _controller: sylius_refund.controller.refund_payment:indexAction
         _sylius:
+            template: "@SyliusRefundPlugin/Order/Admin/RefundPayment/list.html.twig"
             criteria:
                 orderNumber: $orderNumber
-            template: "@SyliusRefundPlugin/Order/Admin/CreditMemo/list.html.twig"
 
 sylius_refund_complete_refund_payment:
     path: /orders/{orderNumber}/refund-payments/{id}/complete

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -10,6 +10,9 @@ sylius_resource:
         sylius_refund.credit_memo:
             classes:
                 model: Sylius\RefundPlugin\Entity\CreditMemo
+        sylius_refund.refund_payment:
+            classes:
+                model: Sylius\RefundPlugin\Entity\RefundPayment
 
 sylius_mailer:
     sender:

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -37,6 +37,18 @@ winzou_state_machine:
             refund:
                 from: [new, fulfilled]
                 to: fully_refunded
+    sylius_refund_refund_payment:
+        class: Sylius\RefundPlugin\Entity\RefundPayment
+        property_path: state
+        graph: sylius_refund_refund_payment
+        state_machine_class: "%sylius.state_machine.class%"
+        states:
+            new: ~
+            completed: ~
+        transitions:
+            complete:
+                from: [New]
+                to: Completed
 
 knp_snappy:
     pdf:

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -43,8 +43,8 @@ winzou_state_machine:
         graph: sylius_refund_refund_payment
         state_machine_class: "%sylius.state_machine.class%"
         states:
-            new: ~
-            completed: ~
+            New: ~
+            Completed: ~
         transitions:
             complete:
                 from: [New]

--- a/src/Resources/config/doctrine/RefundPayment.orm.xml
+++ b/src/Resources/config/doctrine/RefundPayment.orm.xml
@@ -8,10 +8,6 @@
 >
 
     <entity name="Sylius\RefundPlugin\Entity\RefundPayment" table="sylius_refund_payment">
-        <many-to-one field="paymentMethod" target-entity="Sylius\Component\Payment\Model\PaymentMethodInterface">
-            <join-column name="payment_method_id" referenced-column-name="id" nullable="true" />
-        </many-to-one>
-
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
@@ -21,6 +17,10 @@
         <field name="amount" type="integer" />
         <field name="currencyCode" column="currency_code"/>
         <field name="state" />
+
+        <many-to-one field="paymentMethod" target-entity="Sylius\Component\Payment\Model\PaymentMethodInterface">
+            <join-column name="payment_method_id" referenced-column-name="id" nullable="true" />
+        </many-to-one>
     </entity>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/RefundPayment.orm.xml
+++ b/src/Resources/config/doctrine/RefundPayment.orm.xml
@@ -17,6 +17,7 @@
         </id>
 
         <field name="number"/>
+        <field name="orderNumber" column="order_number"/>
         <field name="amount" type="integer" />
         <field name="currencyCode" column="currency_code"/>
         <field name="state" />

--- a/src/Resources/config/doctrine/RefundPayment.orm.xml
+++ b/src/Resources/config/doctrine/RefundPayment.orm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+
+    <entity name="Sylius\RefundPlugin\Entity\RefundPayment" table="sylius_refund_payment">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="number"/>
+        <field name="amount" type="integer" />
+        <field name="currencyCode" column="currency_code"/>
+        <field name="state" />
+    </entity>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/RefundPayment.orm.xml
+++ b/src/Resources/config/doctrine/RefundPayment.orm.xml
@@ -8,6 +8,10 @@
 >
 
     <entity name="Sylius\RefundPlugin\Entity\RefundPayment" table="sylius_refund_payment">
+        <many-to-one field="paymentMethod" target-entity="Sylius\Component\Payment\Model\PaymentMethodInterface">
+            <join-column name="payment_method_id" referenced-column-name="id" nullable="true" />
+        </many-to-one>
+
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -69,7 +69,7 @@
 
         <service id="sylius_refund_plugin.block_event_listener.order_show.refund_payments" class="Sylius\Bundle\UiBundle\Block\BlockEventListener">
             <argument>@SyliusRefundPlugin/Order/Admin/refundPayments.html.twig</argument>
-            <tag name="kernel.event_listener" event="sonata.block.event.sylius.shop.account.order.show.after_summary" method="onBlockEvent" />
+            <tag name="kernel.event_listener" event="sonata.block.event.sylius.admin.order.show.after_summary" method="onBlockEvent" />
         </service>
 
         <service id="sylius_refund_plugin.repository.credit_memo_sequence" class="Doctrine\ORM\EntityRepository">
@@ -92,6 +92,11 @@
 
         <service id="Sylius\RefundPlugin\Factory\RefundPaymentFactory">
             <argument type="service" id="sylius.repository.payment_method"/>
+        </service>
+
+        <service id="Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplier">
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius_refund.manager.refund_payment" />
         </service>
 
         <service id="Sylius\RefundPlugin\ResponseBuilder\CreditMemoFileResponseBuilder" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -62,9 +62,14 @@
             <argument type="service" id="Sylius\RefundPlugin\Provider\OrderRefundedTotalProvider" />
         </service>
 
-        <service id="sylius_refund_plugin.block_event_listener.order_show" class="Sylius\Bundle\UiBundle\Block\BlockEventListener">
+        <service id="sylius_refund_plugin.block_event_listener.order_show.credit_memos" class="Sylius\Bundle\UiBundle\Block\BlockEventListener">
             <argument>@SyliusRefundPlugin/Order/Admin/creditMemos.html.twig</argument>
             <tag name="kernel.event_listener" event="sonata.block.event.sylius.admin.order.show.after_summary" method="onBlockEvent" />
+        </service>
+
+        <service id="sylius_refund_plugin.block_event_listener.order_show.refund_payments" class="Sylius\Bundle\UiBundle\Block\BlockEventListener">
+            <argument>@SyliusRefundPlugin/Order/Admin/refundPayments.html.twig</argument>
+            <tag name="kernel.event_listener" event="sonata.block.event.sylius.shop.account.order.show.after_summary" method="onBlockEvent" />
         </service>
 
         <service id="sylius_refund_plugin.repository.credit_memo_sequence" class="Doctrine\ORM\EntityRepository">
@@ -84,6 +89,10 @@
         </service>
 
         <service id="Sylius\RefundPlugin\File\TemporaryFileManager" />
+
+        <service id="Sylius\RefundPlugin\Factory\RefundPaymentFactory">
+            <argument type="service" id="sylius.repository.payment_method"/>
+        </service>
 
         <service id="Sylius\RefundPlugin\ResponseBuilder\CreditMemoFileResponseBuilder" />
 

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -32,6 +32,8 @@
             <argument type="service" id="session" />
             <argument type="service" id="sylius_refund.repository.refund_payment" />
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplier" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius.repository.order" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -27,5 +27,11 @@
             <argument type="service" id="session" />
             <argument type="service" id="router" />
         </service>
+
+        <service id="Sylius\RefundPlugin\Action\CompleteRefundPaymentAction">
+            <argument type="service" id="session" />
+            <argument type="service" id="sylius_refund.repository.refund_payment" />
+            <argument type="service" id="Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplier" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -18,6 +18,7 @@
         <service id="Sylius\RefundPlugin\Action\Admin\OrderRefundsListAction">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
+            <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="twig" />
         </service>
 

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -20,6 +20,7 @@
             <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="twig" />
+            <argument type="service" id="sylius.context.channel" />
         </service>
 
         <service id="Sylius\RefundPlugin\Action\Admin\RefundUnitsAction">

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -32,9 +32,9 @@
         <service id="Sylius\RefundPlugin\Action\CompleteRefundPaymentAction">
             <argument type="service" id="session" />
             <argument type="service" id="sylius_refund.repository.refund_payment" />
+            <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\RefundPaymentCompletedStateApplier" />
             <argument type="service" id="router" />
-            <argument type="service" id="sylius.repository.order" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/command_bus.xml
+++ b/src/Resources/config/services/command_bus.xml
@@ -12,8 +12,6 @@
             <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />
             <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalChecker" />
-            <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolver" />
             <tag name="prooph_service_bus.sylius_refund_command_bus.route_target" message-detection="true" />
         </service>
 

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -9,6 +9,9 @@
         <service id="Sylius\RefundPlugin\Listener\UnitsRefundedEventListener">
             <argument type="service" id="session" />
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolver" />
+            <argument type="service" id="Sylius\RefundPlugin\Generator\SequentialNumberGenerator" />
+            <argument type="service" id="Sylius\RefundPlugin\Factory\RefundPaymentFactory" />
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
             <tag name="prooph_service_bus.sylius_refund_event_bus.route_target" message-detection="true" />
         </service>
 

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -7,6 +7,8 @@ sylius_refund:
         manage_credit_memos: Manage credit memos
         order_number: Order number
         refund_all: Refund all
+        refund_payment_completed: Refund payment completed sucessfully
+        refund_payments: Refund payments
         refunded_total: Refunded total
         refunds: Refunds
 

--- a/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
+++ b/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
@@ -9,6 +9,7 @@
             <tr>
                 <th>{{ 'sylius.ui.number'|trans }}</th>
                 <th>{{ 'sylius.ui.total'|trans }}</th>
+                <th>{{ 'sylius.ui.state'|trans }}</th>
                 <th>{{ 'sylius.ui.actions'|trans }}</th>
             </tr>
             </thead>
@@ -16,15 +17,15 @@
             {% for refund_payment in refund_payments %}
                 <tr>
                     <td>{{ refund_payment.number }}</td>
-                    <td>{{ money.format(refund_payment.total, refund_payment.currencyCode) }}</td>
+                    <td>{{ money.format(refund_payment.amount, refund_payment.currencyCode) }}</td>
+                    <td>{{ refund_payment.state }}</td>
                     <td class="aligned collapsing">
-                        {{ buttons.default(
-                            path('sylius_refund_complete_refund_payment', {'orderNumber': refund_payment.orderNumber, 'id': refund_payment.id}),
-                            'sylius.ui.show',
-                            null,
-                            'check',
-                            'green'
-                        ) }}
+                        <form action="{{ path('sylius_refund_complete_refund_payment', {'orderNumber': refund_payment.orderNumber, 'id': refund_payment.id}) }}" method="POST">
+                            <button class="button ui labeled icon yellow" {% if refund_payment.state == 'Completed'%} disabled {% endif %}>
+                                <i class="icon check"></i>
+                                {{ 'sylius.ui.complete'|trans }}
+                            </button>
+                        </form>
                     </td>
                 </tr>
             {% endfor %}

--- a/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
+++ b/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
@@ -1,0 +1,34 @@
+{% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+{% import "@SyliusUi/Macro/buttons.html.twig" as buttons %}
+
+{% if refund_payments|length > 0 %}
+    <div class="ui segment" id="refund-payments">
+        <h3 class="ui dividing header">{{ 'sylius_refund.ui.refund_payments'|trans }}</h3>
+        <table class="ui celled compact small table fixed">
+            <thead>
+            <tr>
+                <th>{{ 'sylius.ui.number'|trans }}</th>
+                <th>{{ 'sylius.ui.total'|trans }}</th>
+                <th>{{ 'sylius.ui.actions'|trans }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for refund_payment in refund_payments %}
+                <tr>
+                    <td>{{ refund_payment.number }}</td>
+                    <td>{{ money.format(refund_payment.total, refund_payment.currencyCode) }}</td>
+                    <td class="aligned collapsing">
+                        {{ buttons.default(
+                            path('sylius_refund_complete_refund_payment', {'orderNumber': refund_payment.orderNumber, 'id': refund_payment.id}),
+                            'sylius.ui.show',
+                            null,
+                            'check',
+                            'green'
+                        ) }}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endif %}

--- a/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
+++ b/src/Resources/views/Order/Admin/RefundPayment/list.html.twig
@@ -19,14 +19,16 @@
                     <td>{{ refund_payment.number }}</td>
                     <td>{{ money.format(refund_payment.amount, refund_payment.currencyCode) }}</td>
                     <td>{{ refund_payment.state }}</td>
-                    <td class="aligned collapsing">
-                        <form action="{{ path('sylius_refund_complete_refund_payment', {'orderNumber': refund_payment.orderNumber, 'id': refund_payment.id}) }}" method="POST">
-                            <button class="button ui labeled icon yellow" {% if refund_payment.state == 'Completed'%} disabled {% endif %}>
-                                <i class="icon check"></i>
-                                {{ 'sylius.ui.complete'|trans }}
-                            </button>
-                        </form>
-                    </td>
+                    {% if refund_payment.state != 'Completed'%}
+                        <td class="aligned collapsing">
+                            <form action="{{ path('sylius_refund_complete_refund_payment', {'orderNumber': refund_payment.orderNumber, 'id': refund_payment.id}) }}" method="POST">
+                                <button class="button ui labeled icon yellow">
+                                    <i class="icon check"></i>
+                                    {{ 'sylius.ui.complete'|trans }}
+                                </button>
+                            </form>
+                        </td>
+                    {% endif %}
                 </tr>
             {% endfor %}
             </tbody>

--- a/src/Resources/views/Order/Admin/refundPayments.html.twig
+++ b/src/Resources/views/Order/Admin/refundPayments.html.twig
@@ -1,0 +1,1 @@
+{{ render(path('sylius_refund_order_refund_payment_list', {'orderNumber': block.settings.resource.number})) }}

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -95,6 +95,15 @@
                         </tbody>
                     </table>
 
+                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown">
+                        <option value="" disabled>Payment methods</option>
+                        {% for payment_method in payment_methods %}
+                            <option value="{{ payment_method.id }}">{{ payment_method.name }}</option>
+                        {% endfor %}
+                    </select>
+
+                    <br/>
+
                     <div class="ui buttons">
                         <a id="back" href="{{ path('sylius_admin_order_show', {'id': order.id}) }}" class="ui button">{{ 'sylius.ui.back'|trans }}</a>
                         <div class="or"></div>

--- a/src/StateResolver/RefundPaymentCompletedStateApplier.php
+++ b/src/StateResolver/RefundPaymentCompletedStateApplier.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\StateResolver;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+final class RefundPaymentCompletedStateApplier implements RefundPaymentCompletedStateApplierInterface
+{
+    /** @var StateMachineFactoryInterface */
+    private $stateMachineFactory;
+
+    /** @var ObjectManager */
+    private $refundPaymentManager;
+
+    public function __construct(StateMachineFactoryInterface $stateMachineFactory, ObjectManager $refundPaymentManager)
+    {
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->refundPaymentManager = $refundPaymentManager;
+    }
+
+    public function apply(RefundPaymentInterface $refundPayment): void
+    {
+        $this->stateMachineFactory
+            ->get($refundPayment, RefundPaymentTransitions::GRAPH)
+            ->apply(RefundPaymentTransitions::TRANSITION_COMPLETE)
+        ;
+
+        $this->refundPaymentManager->flush();
+    }
+}

--- a/src/StateResolver/RefundPaymentCompletedStateApplierInterface.php
+++ b/src/StateResolver/RefundPaymentCompletedStateApplierInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\StateResolver;
+
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+interface RefundPaymentCompletedStateApplierInterface
+{
+    public function apply(RefundPaymentInterface $refundPayment): void;
+}

--- a/src/StateResolver/RefundPaymentTransitions.php
+++ b/src/StateResolver/RefundPaymentTransitions.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\StateResolver;
+
+final class RefundPaymentTransitions
+{
+    public const GRAPH = 'sylius_refund_refund_payment';
+
+    public const TRANSITION_COMPLETE = 'complete';
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/Application/app/config/config_test.yml
+++ b/tests/Application/app/config/config_test.yml
@@ -7,4 +7,4 @@ doctrine:
 
 knp_snappy:
     pdf:
-        binary: "/usr/local/bin/wkhtmltopdf"
+        binary: "%kernel.project_dir%/app/etc/wkhtmltopdf"

--- a/tests/Application/app/config/config_test.yml
+++ b/tests/Application/app/config/config_test.yml
@@ -7,4 +7,4 @@ doctrine:
 
 knp_snappy:
     pdf:
-        binary: "%kernel.project_dir%/app/etc/wkhtmltopdf"
+        binary: "/usr/local/bin/wkhtmltopdf"

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -10,6 +10,7 @@ use Prooph\ServiceBus\Exception\CommandDispatchException;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -55,35 +56,43 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @When /^I decide to refund (\d)st "([^"]+)" product$/
+     * @When /^I decide to refund (\d)st "([^"]+)" product with ("[^"]+" payment)$/
      */
-    public function decideToRefundProduct(int $unitNumber, string $productName): void
+    public function decideToRefundProduct(int $unitNumber, string $productName, PaymentMethodInterface $paymentMethod): void
     {
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
-        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], $paymentMethod->getId()));
     }
 
     /**
-     * @When I decide to refund order shipment
+     * @When /^I decide to refund order shipment with ("[^"]+" payment)$/
      */
-    public function decideToRefundOrderShipment(): void
+    public function decideToRefundOrderShipment(PaymentMethodInterface $paymentMethod): void
     {
         $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
 
-        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], '1'));
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], $paymentMethod->getId()));
     }
 
     /**
-     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
+     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product with ("[^"]+" payment)$/
      */
-    public function decideToRefundProductAndShipment(int $unitNumber, string $productName): void
-    {
+    public function decideToRefundProductAndShipment(
+        int $unitNumber,
+        string $productName,
+        PaymentMethodInterface $paymentMethod
+    ): void {
         $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         $this->commandBus->dispatch(
-            new RefundUnits($this->order->getNumber(), [$unit->getId()], [$shippingAdjustment->getId()], '1')
+            new RefundUnits(
+                $this->order->getNumber(),
+                [$unit->getId()],
+                [$shippingAdjustment->getId()],
+                $paymentMethod->getId()
+            )
         );
     }
 
@@ -109,7 +118,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], 1));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -125,7 +134,7 @@ final class RefundingContext implements Context
         $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], '1'));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], 1));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -134,14 +143,22 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @Then /^I should(?:| still) be able to refund (\d)(?:|st|nd|rd) unit with product "([^"]+)"$/
+     * @Then /^I should(?:| still) be able to refund (\d)(?:|st|nd|rd) unit with product "([^"]+)" with ("[^"]+" payment)$/
      */
-    public function shouldBeAbleToRefundUnitWithProduct(int $unitNumber, string $productName): void
-    {
+    public function shouldBeAbleToRefundUnitWithProduct(
+        int $unitNumber,
+        string $productName,
+        PaymentMethodInterface $paymentMethod
+    ): void {
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
+            $this->commandBus->dispatch(new RefundUnits(
+                $this->order->getNumber(),
+                [$unit->getId()],
+                [],
+                $paymentMethod->getId())
+            );
         } catch (CommandDispatchException $exception) {
             throw new \Exception('RefundUnits command should not fail');
         }

--- a/tests/Behat/Context/Application/RefundingContext.php
+++ b/tests/Behat/Context/Application/RefundingContext.php
@@ -61,7 +61,7 @@ final class RefundingContext implements Context
     {
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
-        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
     }
 
     /**
@@ -71,7 +71,7 @@ final class RefundingContext implements Context
     {
         $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
 
-        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()]));
+        $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], '1'));
     }
 
     /**
@@ -83,7 +83,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         $this->commandBus->dispatch(
-            new RefundUnits($this->order->getNumber(), [$unit->getId()], [$shippingAdjustment->getId()])
+            new RefundUnits($this->order->getNumber(), [$unit->getId()], [$shippingAdjustment->getId()], '1')
         );
     }
 
@@ -109,7 +109,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -125,7 +125,7 @@ final class RefundingContext implements Context
         $shippingAdjustment = $this->order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->first();
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()]));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [], [$shippingAdjustment->getId()], '1'));
         } catch (CommandDispatchException $exception) {
             return;
         }
@@ -141,7 +141,7 @@ final class RefundingContext implements Context
         $unit = $this->getOrderUnit($unitNumber, $productName);
 
         try {
-            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], []));
+            $this->commandBus->dispatch(new RefundUnits($this->order->getNumber(), [$unit->getId()], [], '1'));
         } catch (CommandDispatchException $exception) {
             throw new \Exception('RefundUnits command should not fail');
         }

--- a/tests/Behat/Context/Setup/RefundingContext.php
+++ b/tests/Behat/Context/Setup/RefundingContext.php
@@ -43,7 +43,7 @@ final class RefundingContext implements Context
 
         $unit = $unitsWithProduct[$unitNumber-1];
 
-        $this->commandBus->dispatch(new RefundUnits($orderNumber, [$unit->getId()], []));
+        $this->commandBus->dispatch(new RefundUnits($orderNumber, [$unit->getId()], [], '1'));
     }
 
     /**

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -65,15 +65,15 @@ final class ManagingOrdersContext implements Context
     /**
      * @When I complete the first refund payment
      */
-    public function markTheFirstRefundPaymentAs(): void
+    public function completeTheFirstRefundPayment(): void
     {
         $this->showPage->completeRefundPayment(0);
     }
 
     /**
-     * @Then I should not be able to complete the first refund payment
+     * @Then I should not be able to complete the first refund payment again
      */
-    public function shouldNotBeAbleToCompleteTheFirstRefundPayment(): void
+    public function shouldNotBeAbleToCompleteTheFirstRefundPaymentAgain(): void
     {
         Assert::false($this->showPage->canCompleteRefundPayment(0));
     }

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -63,10 +63,10 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
-     * @When I mark the first refund payment as :status
+     * @When I complete the first refund payment
      */
-    public function markTheFirstRefundPaymentAs(string $status): void
+    public function markTheFirstRefundPaymentAs(): void
     {
-        $this->showPage->markTheFirstRefundPaymentAs($status);
+        $this->showPage->completeRefundPayment(0);
     }
 }

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -53,4 +53,20 @@ final class ManagingOrdersContext implements Context
     {
         Assert::false($this->showPage->hasRefundsButton());
     }
+
+    /**
+     * @Then I should see :count refund payment(s) with status :status
+     */
+    public function shouldSeeRefundPaymentWithStatus(int $count, string $status): void
+    {
+        Assert::true($this->showPage->hasRefundPaymentsWithStatus($count, $status));
+    }
+
+    /**
+     * @When I mark the first refund payment as :status
+     */
+    public function markTheFirstRefundPaymentAs(string $status): void
+    {
+        $this->showPage->markTheFirstRefundPaymentAs($status);
+    }
 }

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -69,4 +69,12 @@ final class ManagingOrdersContext implements Context
     {
         $this->showPage->completeRefundPayment(0);
     }
+
+    /**
+     * @Then I should not be able to complete the first refund payment
+     */
+    public function shouldNotBeAbleToCompleteTheFirstRefundPayment(): void
+    {
+        Assert::false($this->showPage->canCompleteRefundPayment(0));
+    }
 }

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -47,11 +47,12 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @When /^I decide to refund (\d)st "([^"]+)" product$/
+     * @When /^I decide to refund (\d)st "([^"]+)" product using "([^"]+)" payment method$/
      */
-    public function decideToRefundProduct(int $unitNumber, string $productName): void
+    public function decideToRefundProduct(int $unitNumber, string $productName, string $paymentMethodName): void
     {
         $this->orderRefundsPage->pickUnitWithProductToRefund($productName, $unitNumber-1);
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethodName);
         $this->orderRefundsPage->refund();
     }
 
@@ -159,5 +160,21 @@ final class RefundingContext implements Context
     public function shouldBeAbleToRefundUnitWithProduct(int $unitNumber, string $productName): void
     {
         Assert::true($this->orderRefundsPage->isUnitWithProductAvailableToRefund($productName, $unitNumber-1));
+    }
+
+    /**
+     * @Then I should be able to choose refund payment method
+     */
+    public function shouldBeAbleToChooseRefundPaymentMethod(): void
+    {
+        Assert::true($this->orderRefundsPage->canChoosePaymentMethod());
+    }
+
+    /**
+     * @Then there should be :paymentMethod payment method
+     */
+    public function thereShouldBePaymentMethod(string $paymentMethod): void
+    {
+        Assert::true($this->orderRefundsPage->isPaymentMethodVisible($paymentMethod));
     }
 }

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -49,38 +49,41 @@ final class RefundingContext implements Context
     /**
      * @When /^I decide to refund (\d)st "([^"]+)" product using "([^"]+)" payment method$/
      */
-    public function decideToRefundProduct(int $unitNumber, string $productName, string $paymentMethodName): void
+    public function decideToRefundProduct(int $unitNumber, string $productName, string $paymentMethod): void
     {
         $this->orderRefundsPage->pickUnitWithProductToRefund($productName, $unitNumber-1);
-        $this->orderRefundsPage->choosePaymentMethod($paymentMethodName);
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethod);
         $this->orderRefundsPage->refund();
     }
 
     /**
-     * @When I decide to refund all units of this order
+     * @When I decide to refund all units of this order with :paymentMethod payment
      */
-    public function decideToRefundAllUnits(): void
+    public function decideToRefundAllUnits(string $paymentMethod): void
     {
         $this->orderRefundsPage->pickAllUnitsToRefund();
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethod);
         $this->orderRefundsPage->refund();
     }
 
     /**
-     * @When I decide to refund order shipment
+     * @When I decide to refund order shipment using :paymentMethod payment
      */
-    public function decideToRefundOrderShipment(): void
+    public function decideToRefundOrderShipment(string $paymentMethod): void
     {
         $this->orderRefundsPage->pickOrderShipment();
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethod);
         $this->orderRefundsPage->refund();
     }
 
     /**
-     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product$/
+     * @When /^I decide to refund order shipment and (\d)st "([^"]+)" product with "([^"]+)" payment$/
      */
-    public function decideToRefundProductAndShipment(int $unitNumber, string $productName): void
+    public function decideToRefundProductAndShipment(int $unitNumber, string $productName, string $paymentMethod): void
     {
         $this->orderRefundsPage->pickUnitWithProductToRefund($productName, $unitNumber-1);
         $this->orderRefundsPage->pickOrderShipment();
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethod);
         $this->orderRefundsPage->refund();
     }
 

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -47,7 +47,7 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @When /^I decide to refund (\d)st "([^"]+)" product using "([^"]+)" payment method$/
+     * @When /^I decide to refund (\d)st "([^"]+)" product with "([^"]+)" payment$/
      */
     public function decideToRefundProduct(int $unitNumber, string $productName, string $paymentMethod): void
     {
@@ -67,7 +67,7 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @When I decide to refund order shipment using :paymentMethod payment
+     * @When I decide to refund order shipment with "([^"]+)" payment
      */
     public function decideToRefundOrderShipment(string $paymentMethod): void
     {
@@ -158,7 +158,7 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @Then /^I should(?:| still) be able to refund (\d)(?:|st|nd|rd) unit with product "([^"]+)"$/
+     * @Then /^I should(?:| still) be able to refund (\d)(?:|st|nd|rd) unit with product "([^"]+)" with ("[^"]+" payment)$/
      */
     public function shouldBeAbleToRefundUnitWithProduct(int $unitNumber, string $productName): void
     {
@@ -174,10 +174,10 @@ final class RefundingContext implements Context
     }
 
     /**
-     * @Then there should be :paymentMethod payment method
+     * @Then there should be :payment payment method
      */
-    public function thereShouldBePaymentMethod(string $paymentMethod): void
+    public function thereShouldBePaymentMethod(string $payment): void
     {
-        Assert::true($this->orderRefundsPage->isPaymentMethodVisible($paymentMethod));
+        Assert::true($this->orderRefundsPage->isPaymentMethodVisible($payment));
     }
 }

--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -57,6 +57,21 @@ final class RefundingContext implements Context
     }
 
     /**
+     * @When /^I decided to refund (\d)st "([^"]+)" product of the order "([^"]+)" with "([^"]+)" payment$/
+     */
+    public function decidedToRefundProduct(
+        int $unitNumber,
+        string $productName,
+        string $orderNumber,
+        string $paymentMethod
+    ): void {
+        $this->orderRefundsPage->open(['orderNumber' => $orderNumber]);
+        $this->orderRefundsPage->pickUnitWithProductToRefund($productName, $unitNumber-1);
+        $this->orderRefundsPage->choosePaymentMethod($paymentMethod);
+        $this->orderRefundsPage->refund();
+    }
+
+    /**
      * @When I decide to refund all units of this order with :paymentMethod payment
      */
     public function decideToRefundAllUnits(string $paymentMethod): void

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -51,4 +51,14 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
 
         $refundPayment->pressButton('Complete');
     }
+
+    public function canCompleteRefundPayment(int $number): bool
+    {
+        $refundPayments = $this->getDocument()->findAll('css', '#refund-payments tbody tr');
+
+        /** @var NodeElement $refundPayment */
+        $refundPayment = $refundPayments[$number];
+
+        return !$refundPayment->findButton('Complete')->hasAttribute('disabled');
+    }
 }

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -59,6 +59,6 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
         /** @var NodeElement $refundPayment */
         $refundPayment = $refundPayments[$number];
 
-        return !$refundPayment->findButton('Complete')->hasAttribute('disabled');
+        return $refundPayment->hasButton('Complete');
     }
 }

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -34,16 +34,21 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
         $refundPaymentsWithStatus = 0;
         /** @var NodeElement $refundPayment */
         foreach ($refundPayments as $refundPayment) {
-            if (strpos($refundPayment, $status)) {
+            if (strpos($refundPayment->getText(), $status)) {
                 $refundPaymentsWithStatus++;
             }
         }
 
-        return $status === $refundPaymentsWithStatus;
+        return $count === $refundPaymentsWithStatus;
     }
 
-    public function markTheFirstRefundPaymentAs(string $status): void
+    public function completeRefundPayment(int $number): void
     {
-        // TODO: Implement markTheFirstRefundPaymentAs() method.
+        $refundPayments = $this->getDocument()->findAll('css', '#refund-payments tbody tr');
+
+        /** @var NodeElement $refundPayment */
+        $refundPayment = $refundPayments[$number];
+
+        $refundPayment->pressButton('Complete');
     }
 }

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -26,4 +26,24 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
     {
         return $this->getDocument()->hasButton('Refunds');
     }
+
+    public function hasRefundPaymentsWithStatus(int $count, string $status): bool
+    {
+        $refundPayments = $this->getDocument()->findAll('css', '#refund-payments tbody tr');
+
+        $refundPaymentsWithStatus = 0;
+        /** @var NodeElement $refundPayment */
+        foreach ($refundPayments as $refundPayment) {
+            if (strpos($refundPayment, $status)) {
+                $refundPaymentsWithStatus++;
+            }
+        }
+
+        return $status === $refundPaymentsWithStatus;
+    }
+
+    public function markTheFirstRefundPaymentAs(string $status): void
+    {
+        // TODO: Implement markTheFirstRefundPaymentAs() method.
+    }
 }

--- a/tests/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/tests/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -13,4 +13,8 @@ interface ShowPageInterface extends BaseOrderShowPageInterface
     public function downloadCreditMemo(int $index): void;
 
     public function hasRefundsButton(): bool;
+
+    public function hasRefundPaymentsWithStatus(int $count, string $status): bool;
+
+    public function markTheFirstRefundPaymentAs(string $status): void;
 }

--- a/tests/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/tests/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -16,5 +16,5 @@ interface ShowPageInterface extends BaseOrderShowPageInterface
 
     public function hasRefundPaymentsWithStatus(int $count, string $status): bool;
 
-    public function markTheFirstRefundPaymentAs(string $status): void;
+    public function completeRefundPayment(int $number): void;
 }

--- a/tests/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/tests/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -16,5 +16,7 @@ interface ShowPageInterface extends BaseOrderShowPageInterface
 
     public function hasRefundPaymentsWithStatus(int $count, string $status): bool;
 
+    public function canCompleteRefundPayment(int $number): bool;
+
     public function completeRefundPayment(int $number): void;
 }

--- a/tests/Behat/Page/Admin/OrderRefundsPage.php
+++ b/tests/Behat/Page/Admin/OrderRefundsPage.php
@@ -85,8 +85,8 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
     protected function getDefinedElements(): array
     {
         return [
-            'refunded_total' => '#refunded-total',
             'payment_methods' => '#payment-methods',
+            'refunded_total' => '#refunded-total',
         ];
     }
 

--- a/tests/Behat/Page/Admin/OrderRefundsPage.php
+++ b/tests/Behat/Page/Admin/OrderRefundsPage.php
@@ -63,10 +63,33 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
         return null !== $this->getDocument()->find('css', 'a:contains("Back")');
     }
 
+    public function choosePaymentMethod(string $paymentMethodName): void
+    {
+        $paymentMethods = $this->getElement('payment_methods');
+
+        $paymentMethods->selectOption($paymentMethodName);
+    }
+
+    public function canChoosePaymentMethod(): bool
+    {
+        return null !== $this->getElement('payment_methods');
+    }
+
+    public function isPaymentMethodVisible(string $paymentMethodName): bool
+    {
+        $paymentMethods = $this->getElement('payment_methods');
+
+        // todo
+        $paymentMethods->getValue();
+
+        return false;
+    }
+
     protected function getDefinedElements(): array
     {
         return [
             'refunded_total' => '#refunded-total',
+            'payment_methods' => '#payment-methods',
         ];
     }
 

--- a/tests/Behat/Page/Admin/OrderRefundsPage.php
+++ b/tests/Behat/Page/Admin/OrderRefundsPage.php
@@ -79,10 +79,7 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
     {
         $paymentMethods = $this->getElement('payment_methods');
 
-        // todo
-        $paymentMethods->getValue();
-
-        return false;
+        return strpos($paymentMethods->getText(), $paymentMethodName) !== false;
     }
 
     protected function getDefinedElements(): array

--- a/tests/Behat/Page/Admin/OrderRefundsPageInterface.php
+++ b/tests/Behat/Page/Admin/OrderRefundsPageInterface.php
@@ -25,4 +25,10 @@ interface OrderRefundsPageInterface extends SymfonyPageInterface
     public function isOrderShipmentAvailableToRefund(): bool;
 
     public function hasBackButton(): bool;
+
+    public function choosePaymentMethod(string $paymentMethodName): void;
+
+    public function canChoosePaymentMethod(): bool;
+
+    public function isPaymentMethodVisible(string $paymentMethodName): bool;
 }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -26,6 +26,9 @@ default:
                 - sylius.behat.context.setup.shipping
                 - sylius.behat.context.setup.taxation
                 - sylius.behat.context.setup.zone
+
+                - sylius.behat.context.transform.payment
+
                 - Tests\Sylius\RefundPlugin\Behat\Context\Setup\RefundingContext
 
                 - sylius.behat.context.ui.admin.managing_orders
@@ -61,6 +64,9 @@ default:
                 - sylius.behat.context.setup.shipping
                 - sylius.behat.context.setup.taxation
                 - sylius.behat.context.setup.zone
+
+                - sylius.behat.context.transform.payment
+
                 - Tests\Sylius\RefundPlugin\Behat\Context\Setup\RefundingContext
 
                 - Tests\Sylius\RefundPlugin\Behat\Context\Application\CreditMemoContext
@@ -94,6 +100,8 @@ default:
                 - sylius.behat.context.setup.user
 
                 - sylius.behat.context.ui.shop.account
+
+                - sylius.behat.context.transform.payment
 
                 - Tests\Sylius\RefundPlugin\Behat\Context\Ui\Shop\Customer\CreditMemoContext
                 - Tests\Sylius\RefundPlugin\Behat\Context\Setup\RefundingContext


### PR DESCRIPTION
<img width="1232" alt="screen shot 2018-08-17 at 14 47 24" src="https://user-images.githubusercontent.com/22262296/44266925-a11b9400-a22c-11e8-89b5-0bcf5daa5df7.png">

<img width="906" alt="screen shot 2018-08-17 at 14 48 11" src="https://user-images.githubusercontent.com/22262296/44266929-a547b180-a22c-11e8-868b-bd6f2fcac865.png">

Things to improve after merge:
* Create simple PaymentMethod model in RefundPlugin instead of using model taken from Sylius
* UI (forms, selects)
* Rethink refund payment number (right now it's reused sequence)

Since making this task done required a lot of code, I would focus on bullet points mentioned above in a separate PRs.