### PR TITLE
Refund payment completed notification

### DIFF
--- a/features/completing_refund_payment.feature
+++ b/features/completing_refund_payment.feature
@@ -21,6 +21,7 @@ Feature: Completing refund payment
     Scenario: Completing refund payment
         When I view the summary of the order "#00000022"
         And I complete the first refund payment
+        Then I should be notified that refund payment has been successfully completed
         Then I should see 1 refund payment with status "Completed"
 
     @ui

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -1,4 +1,5 @@
 sylius_refund:
     at_least_one_unit_should_be_selected_to_refund: 'At least one unit should be selected to refund'
     order_should_be_paid: 'Order should be paid for the units to could be refunded'
+    refund_payment_completed: 'Refund payment has been successfully completed'
     units_successfully_refunded: 'Selected order units have been successfully refunded'

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -71,6 +71,17 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then I should be notified that refund payment has been successfully completed
+     */
+    public function shouldBeNotifiedThatRefundPaymentHasBeenSuccessfullyCompleted(): void
+    {
+        $this->notificationChecker->checkNotification(
+            'Refund payment has been successfully completed',
+            NotificationType::success()
+        );
+    }
+
+    /**
      * @Then I should not be able to complete the first refund payment again
      */
     public function shouldNotBeAbleToCompleteTheFirstRefundPaymentAgain(): void


### PR DESCRIPTION
Based on https://github.com/Sylius/RefundPlugin/pull/38

Before:

<img width="1157" alt="zrzut ekranu 2018-08-20 o 15 56 19" src="https://user-images.githubusercontent.com/6212718/44345090-9c581980-a492-11e8-8e6c-0d63439168d8.png">

After:

<img width="1161" alt="zrzut ekranu 2018-08-20 o 16 02 27" src="https://user-images.githubusercontent.com/6212718/44345099-a24dfa80-a492-11e8-970a-ee92c8bb8092.png">
