### PR TITLE
Improve refund payment method select

### DIFF
--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -95,8 +95,8 @@
                         </tbody>
                     </table>
 
-                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown">
-                        <option value="" disabled>Payment methods</option>
+                    <label for="payment-methods" style="font-weight: bold;">{{ 'sylius.ui.payment_method'|trans }}</label>
+                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown" style="margin-top: 10px;">
                         {% for payment_method in payment_methods %}
                             <option value="{{ payment_method.id }}">{{ payment_method.name }}</option>
                         {% endfor %}


### PR DESCRIPTION
I think it's weird to have "Payment methods" label as a select box option, even if it's a disabled placeholder

Before:

<img width="1150" alt="zrzut ekranu 2018-08-22 o 12 04 09" src="https://user-images.githubusercontent.com/6212718/44457493-a51c2d00-a603-11e8-80b5-f01970b54ea3.png">

After:

<img width="1149" alt="zrzut ekranu 2018-08-22 o 12 03 09" src="https://user-images.githubusercontent.com/6212718/44457501-a9e0e100-a603-11e8-80c1-3581ce7ca3eb.png">
