### PR TITLE
Fix redirect after accessing refund page of unpaid order

### DIFF
--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -21,6 +21,8 @@
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="twig" />
             <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="session" />
+            <argument type="service" id="router" />
         </service>
 
         <service id="Sylius\RefundPlugin\Action\Admin\RefundUnitsAction">


### PR DESCRIPTION
Somehow `'referer'` parameters of `$request` was set in Behat scenarios, but not in regular browser :/ I think that it's a fair assumption, that we want to be redirected to order show page in such a situation.