### PR TITLE
Change "sylius-plugin" to "symfony-bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "sylius/refund-plugin",
-    "type": "sylius-plugin",
+    "type": "symfony-bundle",
+    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "refunds"],
     "description": "Plugin provides basic refunds functionality for Sylius application.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
In order to make this plugin work with SymfonyFlex (see https://github.com/symfony/recipes-contrib/pull/508), I propose a temporary (or maybe not) solution to change `type` in `composer.json` to `symfony-bundle` and put `sylius-plugin` as a keyword (which is also searchable by packagist). If it works, we should consider doing this for all Sylius plugins.