### PR TITLE
Bring back "sylius-plugin" composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sylius/refund-plugin",
-    "type": "symfony-bundle",
+    "type": "sylius-plugin",
     "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "refunds"],
     "description": "Plugin provides basic refunds functionality for Sylius application.",
     "license": "MIT",


### PR DESCRIPTION
**SymfonyFlex** has now support for `sylius-plugin` as a synonymous of `symfony-bundle` :)