### PR TITLE
Remove knp_snappy configuration from config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ From Administrator's point of view, every Refund request results in creating two
         resource: "@SyliusRefundPlugin/Resources/config/routing.yml"
     ````
 
-5. Clear cache:
+5. Configure `KnpSnappyBundle` (if you don't have it configured yet):
+
+    ````yaml
+    knp_snappy:
+        pdf:
+            enabled: true
+            binary: #path to your wkhtmltopdf binary file
+            options: []
+    ````
+
+6. Clear cache:
 
     ```bash
     bin/console cache:clear

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -47,12 +47,6 @@ winzou_state_machine:
                 from: [New]
                 to: Completed
 
-knp_snappy:
-    pdf:
-        enabled: true
-        binary: /usr/local/bin/wkhtmltopdf
-        options: []
-
 sylius_grid:
     templates:
         filter:


### PR DESCRIPTION
As we're planning to introduce **SymfonyFlex** support as far as possible, this change is required to not make conflicts with `KnpSnappyBundle` configuration, that would also be downloaded via **SymfonyFlex**. When **Flex** support will be official, we will for sure have to have two separate installation instructions - with and without **Flex** usage.