### PR TITLE
Change migrations namespace

### DIFF
--- a/migrations/Version20180704112314.php
+++ b/migrations/Version20180704112314.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180718125528.php
+++ b/migrations/Version20180718125528.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180725111447.php
+++ b/migrations/Version20180725111447.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180807090825.php
+++ b/migrations/Version20180807090825.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180817130113.php
+++ b/migrations/Version20180817130113.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180820122703.php
+++ b/migrations/Version20180820122703.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180820132147.php
+++ b/migrations/Version20180820132147.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180821123925.php
+++ b/migrations/Version20180821123925.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180826122832.php
+++ b/migrations/Version20180826122832.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180829090832.php
+++ b/migrations/Version20180829090832.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180907064734.php
+++ b/migrations/Version20180907064734.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;


### PR DESCRIPTION
Namespace migrations in Sylius-Standard is now `DoctrineMigrations` (see https://github.com/Sylius/Sylius-Standard/blob/master/config/packages/doctrine_migrations.yaml#L5), therefore we should follow this convention