### PR TITLE
RefundPayment - Payment relation

### DIFF
--- a/spec/Event/RefundPaymentGeneratedSpec.php
+++ b/spec/Event/RefundPaymentGeneratedSpec.php
@@ -10,12 +10,13 @@ final class RefundPaymentGeneratedSpec extends ObjectBehavior
 {
     function it_represents_an_immutable_fact_that_refund_payment_has_been_generated(): void
     {
-        $this->beConstructedWith(1, '000222', 10000, 'GBP', 2);
+        $this->beConstructedWith(1, '000222', 10000, 'GBP', 2, 3);
 
         $this->id()->shouldReturn(1);
         $this->orderNumber()->shouldReturn('000222');
         $this->amount()->shouldReturn(10000);
         $this->currencyCode()->shouldReturn('GBP');
         $this->paymentMethodId()->shouldReturn(2);
+        $this->paymentId()->shouldReturn(3);
     }
 }

--- a/spec/Provider/DefaultRelatedPaymentIdProviderSpec.php
+++ b/spec/Provider/DefaultRelatedPaymentIdProviderSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\Exception\CompletedPaymentNotFound;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+use Sylius\RefundPlugin\Provider\RelatedPaymentIdProviderInterface;
+
+final class DefaultRelatedPaymentIdProviderSpec extends ObjectBehavior
+{
+    function let(OrderRepositoryInterface $orderRepository): void
+    {
+        $this->beConstructedWith($orderRepository);
+    }
+
+    function it_implements_related_payment_id_provider_interface(): void
+    {
+        $this->shouldImplement(RelatedPaymentIdProviderInterface::class);
+    }
+
+    function it_provides_id_of_last_completed_payment_from_refund_payment_order(
+        OrderRepositoryInterface $orderRepository,
+        RefundPaymentInterface $refundPayment,
+        OrderInterface $order,
+        PaymentInterface $payment
+    ): void {
+        $refundPayment->getOrderNumber()->willReturn('000333');
+
+        $orderRepository->findOneByNumber('000333')->willReturn($order);
+
+        $order->getLastPayment(PaymentInterface::STATE_COMPLETED)->willReturn($payment);
+
+        $payment->getId()->willReturn(4);
+
+        $this->getForRefundPayment($refundPayment)->shouldReturn(4);
+    }
+
+    function it_throws_exception_if_there_is_no_order_with_given_number(
+        OrderRepositoryInterface $orderRepository,
+        RefundPaymentInterface $refundPayment
+    ): void {
+        $refundPayment->getOrderNumber()->willReturn('000666');
+        $orderRepository->findOneByNumber('000666')->willReturn(null);
+
+        $this
+            ->shouldThrow(OrderNotFound::withNumber('000666'))
+            ->during('getForRefundPayment', [$refundPayment])
+        ;
+    }
+
+    function it_throws_exception_if_order_has_no_completed_payments(
+        OrderRepositoryInterface $orderRepository,
+        RefundPaymentInterface $refundPayment,
+        OrderInterface $order
+    ): void {
+        $refundPayment->getOrderNumber()->willReturn('000666');
+        $orderRepository->findOneByNumber('000666')->willReturn($order);
+
+        $order->getLastPayment(PaymentInterface::STATE_COMPLETED)->willReturn(null);
+
+        $this
+            ->shouldThrow(CompletedPaymentNotFound::withNumber('000666'))
+            ->during('getForRefundPayment', [$refundPayment])
+        ;
+    }
+}

--- a/src/Event/RefundPaymentGenerated.php
+++ b/src/Event/RefundPaymentGenerated.php
@@ -21,13 +21,23 @@ final class RefundPaymentGenerated
     /** @var int */
     private $paymentMethodId;
 
-    public function __construct(int $id, string $orderNumber, int $amount, string $currencyCode, int $paymentMethodId)
-    {
+    /** @var int */
+    private $paymentId;
+
+    public function __construct(
+        int $id,
+        string $orderNumber,
+        int $amount,
+        string $currencyCode,
+        int $paymentMethodId,
+        int $paymentId
+    ) {
         $this->id = $id;
         $this->orderNumber = $orderNumber;
         $this->amount = $amount;
         $this->currencyCode = $currencyCode;
         $this->paymentMethodId = $paymentMethodId;
+        $this->paymentId = $paymentId;
     }
 
     public function id(): int
@@ -53,5 +63,10 @@ final class RefundPaymentGenerated
     public function paymentMethodId(): int
     {
         return $this->paymentMethodId;
+    }
+
+    public function paymentId(): int
+    {
+        return $this->paymentId;
     }
 }

--- a/src/Exception/CompletedPaymentNotFound.php
+++ b/src/Exception/CompletedPaymentNotFound.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Exception;
+
+final class CompletedPaymentNotFound extends \InvalidArgumentException
+{
+    public static function withNumber(string $orderNumber): self
+    {
+        return new self(sprintf('Order with number "%s" has no completed payments', $orderNumber));
+    }
+}

--- a/src/ProcessManager/RefundPaymentProcessManager.php
+++ b/src/ProcessManager/RefundPaymentProcessManager.php
@@ -10,12 +10,16 @@ use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
 use Sylius\RefundPlugin\Event\RefundPaymentGenerated;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
 use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
+use Sylius\RefundPlugin\Provider\RelatedPaymentIdProviderInterface;
 use Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolverInterface;
 
 final class RefundPaymentProcessManager
 {
     /** @var OrderFullyRefundedStateResolverInterface */
     private $orderFullyRefundedStateResolver;
+
+    /** @var RelatedPaymentIdProviderInterface */
+    private $relatedPaymentIdProvider;
 
     /** @var RefundPaymentFactoryInterface */
     private $refundPaymentFactory;
@@ -28,11 +32,13 @@ final class RefundPaymentProcessManager
 
     public function __construct(
         OrderFullyRefundedStateResolverInterface $orderFullyRefundedStateResolver,
+        RelatedPaymentIdProviderInterface $relatedPaymentIdProvider,
         RefundPaymentFactoryInterface $refundPaymentFactory,
         EntityManagerInterface $entityManager,
         EventBus $eventBus
     ) {
         $this->orderFullyRefundedStateResolver = $orderFullyRefundedStateResolver;
+        $this->relatedPaymentIdProvider = $relatedPaymentIdProvider;
         $this->refundPaymentFactory = $refundPaymentFactory;
         $this->entityManager = $entityManager;
         $this->eventBus = $eventBus;
@@ -57,7 +63,7 @@ final class RefundPaymentProcessManager
             $event->amount(),
             $event->currencyCode(),
             $event->paymentMethodId(),
-            1
+            $this->relatedPaymentIdProvider->getForRefundPayment($refundPayment)
         ));
 
         $this->orderFullyRefundedStateResolver->resolve($event->orderNumber());

--- a/src/ProcessManager/RefundPaymentProcessManager.php
+++ b/src/ProcessManager/RefundPaymentProcessManager.php
@@ -56,7 +56,8 @@ final class RefundPaymentProcessManager
             $event->orderNumber(),
             $event->amount(),
             $event->currencyCode(),
-            $event->paymentMethodId()
+            $event->paymentMethodId(),
+            1
         ));
 
         $this->orderFullyRefundedStateResolver->resolve($event->orderNumber());

--- a/src/Provider/DefaultRelatedPaymentIdProvider.php
+++ b/src/Provider/DefaultRelatedPaymentIdProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Provider;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\Exception\CompletedPaymentNotFound;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+
+final class DefaultRelatedPaymentIdProvider implements RelatedPaymentIdProviderInterface
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    public function __construct(OrderRepositoryInterface $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function getForRefundPayment(RefundPaymentInterface $refundPayment): int
+    {
+        $orderNumber = $refundPayment->getOrderNumber();
+        /** @var OrderInterface|null $order */
+        $order = $this->orderRepository->findOneByNumber($orderNumber);
+
+        if ($order === null) {
+            throw OrderNotFound::withNumber($orderNumber);
+        }
+
+        $payment = $order->getLastPayment(PaymentInterface::STATE_COMPLETED);
+
+        if ($payment === null) {
+            throw CompletedPaymentNotFound::withNumber($orderNumber);
+        }
+
+        return $payment->getId();
+    }
+}

--- a/src/Provider/RelatedPaymentIdProviderInterface.php
+++ b/src/Provider/RelatedPaymentIdProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Provider;
+
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+
+interface RelatedPaymentIdProviderInterface
+{
+    public function getForRefundPayment(RefundPaymentInterface $refundPayment): int;
+}

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -20,6 +20,7 @@
 
         <service id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager">
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolver" />
+            <argument type="service" id="Sylius\RefundPlugin\Provider\RelatedPaymentIdProviderInterface" />
             <argument type="service" id="Sylius\RefundPlugin\Factory\RefundPaymentFactory" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="prooph_service_bus.sylius_refund_event_bus" />

--- a/src/Resources/config/services/provider.xml
+++ b/src/Resources/config/services/provider.xml
@@ -27,5 +27,9 @@
         <service id="Sylius\RefundPlugin\Provider\UnitRefundedTotalProvider">
             <argument type="service" id="sylius_refund.repository.refund" />
         </service>
+
+        <service id="Sylius\RefundPlugin\Provider\RelatedPaymentIdProviderInterface" class="Sylius\RefundPlugin\Provider\DefaultRelatedPaymentIdProvider">
+            <argument type="service" id="sylius.repository.order" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
The necessity of this change is connected with the future possibilities of supporting payment methods with other than **offline** gateways. Usually, for integration with payment gateways as PayPal or stripe, we need to have reference to an actual Order payment. Of course, there are some problems with this approach, but I think they can be safely ignored (😄) for now:

**What if there is more than one order payment? Which should be related?**

IMO the fair assumption is, we operate on only one payment for now. As explained in [similar issue](https://github.com/Sylius/AdminOrderCreationPlugin/issues/52) on `AdminOrderCreationPlugin`, even though Sylius gives a possibility to operates on split payments, there is no such feature out-of-the-box. After all, this is *Sylius plugin*, we need to provide a good and easily extended implementation, rather than think about every possible possibility.

**What about the partial refunds? Should they all be related to one the same payment?**

For now yes, regarding the split payments explanation from the previous question 😄 

If (when) we provide other gateways integrations in the future (my dream is to have PayPal and Stripe supported out-of-the-box, as in Sylius), there will be more questions about handling this relation, for sure. Right now we must trust in plugin users' developing skills (however every opinion or contribution would be appreciated :)).

CC @kortwotze as I've talked about this feature a few days ago, I suppose you still need it 🚀 

PS. When I wrote this description, I've realized, that supporting **only** offline gateways is a missing feature 😄 Well, it should be implemented (https://github.com/Sylius/RefundPlugin/pull/33) but something went wrong (https://github.com/Sylius/RefundPlugin/blob/master/src/Action/Admin/OrderRefundsListAction.php#L63). Anyway, it should be implemented (supporting other than offline gateways is not tested at all) and I will change it in separate PR 💣 