### PR TITLE
Hide unneeded "refund" button

### DIFF
--- a/src/Resources/views/SyliusAdminBundle/Order/Show/_payment.html.twig
+++ b/src/Resources/views/SyliusAdminBundle/Order/Show/_payment.html.twig
@@ -1,0 +1,26 @@
+{% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+{% import '@SyliusUi/Macro/labels.html.twig' as label %}
+
+<div class="item">
+    <div class="right floated content">
+        {{ label.default(('sylius.ui.'~payment.state)|trans) }}
+    </div>
+    <i class="large payment icon"></i>
+    <div class="content">
+        <div class="header">
+            {{ payment.method }}
+        </div>
+        <div class="description">
+            {{ money.format(payment.amount, payment.order.currencyCode) }}
+        </div>
+    </div>
+    {% if sm_can(payment, 'complete', 'sylius_payment') %}
+        <div class="ui segment">
+            <form action="{{ path('sylius_admin_order_payment_complete', {'orderId': order.id, 'id': payment.id}) }}" method="post" novalidate>
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+                <input type="hidden" name="_method" value="PUT">
+                <button type="submit" class="ui icon labeled tiny blue fluid loadable button"><i class="check icon"></i> {{ 'sylius.ui.complete'|trans }}</button>
+            </form>
+        </div>
+    {% endif %}
+</div>

--- a/tests/Application/templates/bundles/SyliusAdminBundle/Order/Show/_payment.html.twig
+++ b/tests/Application/templates/bundles/SyliusAdminBundle/Order/Show/_payment.html.twig
@@ -1,0 +1,26 @@
+{% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+{% import '@SyliusUi/Macro/labels.html.twig' as label %}
+
+<div class="item">
+    <div class="right floated content">
+        {{ label.default(('sylius.ui.'~payment.state)|trans) }}
+    </div>
+    <i class="large payment icon"></i>
+    <div class="content">
+        <div class="header">
+            {{ payment.method }}
+        </div>
+        <div class="description">
+            {{ money.format(payment.amount, payment.order.currencyCode) }}
+        </div>
+    </div>
+    {% if sm_can(payment, 'complete', 'sylius_payment') %}
+        <div class="ui segment">
+            <form action="{{ path('sylius_admin_order_payment_complete', {'orderId': order.id, 'id': payment.id}) }}" method="post" novalidate>
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token(payment.id) }}" />
+                <input type="hidden" name="_method" value="PUT">
+                <button type="submit" class="ui icon labeled tiny blue fluid loadable button"><i class="check icon"></i> {{ 'sylius.ui.complete'|trans }}</button>
+            </form>
+        </div>
+    {% endif %}
+</div>


### PR DESCRIPTION
Before:

<img width="278" alt="zrzut ekranu 2018-10-31 o 11 00 42" src="https://user-images.githubusercontent.com/6212718/47780848-8a99ba80-dcfc-11e8-8e20-fc2c2c1522c3.png">

After:

<img width="275" alt="zrzut ekranu 2018-10-31 o 10 58 24" src="https://user-images.githubusercontent.com/6212718/47780853-8f5e6e80-dcfc-11e8-9453-8cffbe823fb0.png">

As we provide a sophisticated and quite expanded refunds system in this plugin, there is no need to keep this dummy **Refund** plugin anymore :) See https://github.com/Sylius/RefundPlugin/issues/16 for more details