### PR TITLE
Mention default_bus configuration in installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ From Administrator's point of view, every Refund request results in creating two
     cp -R vendor/sylius/refund-plugin/src/Resources/views/SyliusAdminBundle/* templates/bundles/SyliusAdminBundle/
     ```
 
+4. (optional) If you don't use `symfony/messenger` component yet, it is required to configure one of the message buses as a default bus:
+
+    ```yaml
+    framework:
+        messenger:
+            default_bus: sylius_refund_plugin.command_bus
+    ```
+
 #### Beware!
 
 This installation instruction assumes that you're using Symfony Flex. If you don't, take a look at the

--- a/docs/legacy_installation.md
+++ b/docs/legacy_installation.md
@@ -38,14 +38,14 @@
             options: []
     ````
     
-2. Copy plugin migrations to your migrations directory (e.g. `src/Migrations`) and apply them to your database:
+6. Copy plugin migrations to your migrations directory (e.g. `src/Migrations`) and apply them to your database:
 
     ```bash
     cp -R vendor/sylius/refund-plugin/migrations/* src/Migrations
     bin/console doctrine:migrations:migrate
     ```
 
-3. Copy Sylius templates overridden in plugin to your templates directory (e.g `templates/bundles/`):
+7. Copy Sylius templates overridden in plugin to your templates directory (e.g `templates/bundles/`):
 
     ```bash
     mkdir -p templates/bundles/SyliusAdminBundle/
@@ -56,4 +56,12 @@
 
     ```bash
     bin/console cache:clear
+    ```
+
+9. (optional) If you don't use `symfony/messenger` component yet, it is required to configure one of the message buses as a default bus:
+
+    ```yaml
+    framework:
+        messenger:
+            default_bus: sylius_refund_plugin.command_bus
     ```


### PR DESCRIPTION
Fixes #100.

The only thing that worries me, is that it still would throw an exception after SymfonyFlex configuration if there is no default_bus configured (during cache:clear).
The best solution would be to run some script after configuration and before clearing cache asking "Which command bus you want to setup as default?".
But right now it's better than it was :)