### PR TITLE
"To" and "From" addresses on Credit Memo

### DIFF
--- a/features/having_credit_memo_generated.feature
+++ b/features/having_credit_memo_generated.feature
@@ -6,6 +6,7 @@ Feature: Having credit memo generated
 
     Background:
         Given the store operates on a single green channel in "United States"
+        And channel "United States" billing data is "Haas & Milan", "Pacific Coast Hwy", "223000" "Los Angeles", "United States" with "1100110011" tax ID
         And default tax zone is "US"
         And the store has "US VAT" tax rate of 10% for "Clothes" within the "US" zone
         And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
@@ -16,9 +17,11 @@ Feature: Having credit memo generated
         And this promotion gives "$1.00" off on every product with minimum price at "$5.00"
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
         And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer "rick.sanchez@wubba-lubba-dub-dub.com" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And there is a customer "morty.smith@look-at-me.com" that placed an order "#00000023"
         And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer "morty.smith@look-at-me.com" addressed it to "Main St.", "90100" "Los Angeles" in the "United States" with identical billing address
         And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
         And the order "#00000023" is already paid
         And I am logged in as an administrator
@@ -38,6 +41,8 @@ Feature: Having credit memo generated
         And it should have sequential number generated from current date
         Then this credit memo should contain 1 "Mr. Meeseeks T-Shirt" product with "$0.90" tax applied
         And it should be issued in "United States" channel
+        And it should be issued from "Rick Sanchez", "Seaside Fwy", "90802" "Los Angeles" in the "United States"
+        And it should be issued to "Haas & Milan", "Pacific Coast Hwy", "223000" "Los Angeles" in the "United States"
         And its total should be "$9.90"
 
     @ui @application
@@ -48,7 +53,6 @@ Feature: Having credit memo generated
         Then this credit memo should contain 1 "Mr. Meeseeks T-Shirt" product with "$0.50" tax applied
         And it should be issued in "United States" channel
         And its total should be "$5.50"
-
 
     @ui @application
     Scenario: Seeing the details of generated credit memo with partial shipment price

--- a/features/having_credit_memo_generated.feature
+++ b/features/having_credit_memo_generated.feature
@@ -6,7 +6,7 @@ Feature: Having credit memo generated
 
     Background:
         Given the store operates on a single green channel in "United States"
-        And channel "United States" billing data is "Haas & Milan", "Pacific Coast Hwy", "223000" "Los Angeles", "United States" with "1100110011" tax ID
+        And channel "United States" billing data is "Haas & Milan", "Pacific Coast Hwy", "90003" "Los Angeles", "United States" with "1100110011" tax ID
         And default tax zone is "US"
         And the store has "US VAT" tax rate of 10% for "Clothes" within the "US" zone
         And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
@@ -42,7 +42,7 @@ Feature: Having credit memo generated
         Then this credit memo should contain 1 "Mr. Meeseeks T-Shirt" product with "$0.90" tax applied
         And it should be issued in "United States" channel
         And it should be issued from "Rick Sanchez", "Seaside Fwy", "90802" "Los Angeles" in the "United States"
-        And it should be issued to "Haas & Milan", "Pacific Coast Hwy", "223000" "Los Angeles" in the "United States"
+        And it should be issued to "Haas & Milan", "Pacific Coast Hwy", "90003" "Los Angeles" in the "United States" with "1100110011" tax ID
         And its total should be "$9.90"
 
     @ui @application

--- a/features/having_credit_memo_generated.feature
+++ b/features/having_credit_memo_generated.feature
@@ -17,12 +17,12 @@ Feature: Having credit memo generated
         And this promotion gives "$1.00" off on every product with minimum price at "$5.00"
         And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
         And the customer bought 2 "Mr. Meeseeks T-Shirt" products
-        And the customer "rick.sanchez@wubba-lubba-dub-dub.com" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
-        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And the customer "Rick Sanchez" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
+        And the customer chose "Galaxy Post" shipping method with "Space money" payment
         And there is a customer "morty.smith@look-at-me.com" that placed an order "#00000023"
         And the customer bought 2 "Mr. Meeseeks T-Shirt" products
-        And the customer "morty.smith@look-at-me.com" addressed it to "Main St.", "90100" "Los Angeles" in the "United States" with identical billing address
-        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And the customer "Morty Smith" addressed it to "Main St.", "90100" "Los Angeles" in the "United States" with identical billing address
+        And the customer chose "Galaxy Post" shipping method with "Space money" payment
         And the order "#00000023" is already paid
         And I am logged in as an administrator
         And the order "#00000022" is already paid

--- a/features/having_credit_memo_generated.feature
+++ b/features/having_credit_memo_generated.feature
@@ -11,7 +11,7 @@ Feature: Having credit memo generated
         And the store has "US VAT" tax rate of 10% for "Clothes" within the "US" zone
         And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
         And it belongs to "Clothes" tax category
-        And the store allows shipping with "Galaxy Post"
+        And the store has "Galaxy Post" shipping method with "$10.00" fee
         And the store allows paying with "Space money"
         And there is a promotion "Anatomy Park Promotion"
         And this promotion gives "$1.00" off on every product with minimum price at "$5.00"

--- a/migrations/Version20190215134758.php
+++ b/migrations/Version20190215134758.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190215134758 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_refund_credit_memo ADD from_customerName VARCHAR(255) NOT NULL, ADD from_street VARCHAR(255) NOT NULL, ADD from_postcode VARCHAR(255) NOT NULL, ADD from_countryCode VARCHAR(255) NOT NULL, ADD from_city VARCHAR(255) NOT NULL, ADD from_company VARCHAR(255) DEFAULT NULL, ADD from_provinceName VARCHAR(255) DEFAULT NULL, ADD from_provinceCode VARCHAR(255) DEFAULT NULL, ADD to_company VARCHAR(255) NOT NULL, ADD to_taxId VARCHAR(255) NOT NULL, ADD to_countryCode VARCHAR(255) NOT NULL, ADD to_street VARCHAR(255) NOT NULL, ADD to_city VARCHAR(255) NOT NULL, ADD to_postcode VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_refund_credit_memo DROP from_customerName, DROP from_street, DROP from_postcode, DROP from_countryCode, DROP from_city, DROP from_company, DROP from_provinceName, DROP from_provinceCode, DROP to_company, DROP to_taxId, DROP to_countryCode, DROP to_street, DROP to_city, DROP to_postcode');
+    }
+}

--- a/migrations/Version20190215154028.php
+++ b/migrations/Version20190215154028.php
@@ -7,22 +7,14 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
-final class Version20190215134758 extends AbstractMigration
+final class Version20190215154028 extends AbstractMigration
 {
-    public function getDescription() : string
-    {
-        return '';
-    }
-
     public function up(Schema $schema) : void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_refund_credit_memo ADD from_customerName VARCHAR(255) NOT NULL, ADD from_street VARCHAR(255) NOT NULL, ADD from_postcode VARCHAR(255) NOT NULL, ADD from_countryCode VARCHAR(255) NOT NULL, ADD from_city VARCHAR(255) NOT NULL, ADD from_company VARCHAR(255) DEFAULT NULL, ADD from_provinceName VARCHAR(255) DEFAULT NULL, ADD from_provinceCode VARCHAR(255) DEFAULT NULL, ADD to_company VARCHAR(255) NOT NULL, ADD to_taxId VARCHAR(255) NOT NULL, ADD to_countryCode VARCHAR(255) NOT NULL, ADD to_street VARCHAR(255) NOT NULL, ADD to_city VARCHAR(255) NOT NULL, ADD to_postcode VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE sylius_refund_credit_memo ADD from_customerName VARCHAR(255) NOT NULL, ADD from_street VARCHAR(255) NOT NULL, ADD from_postcode VARCHAR(255) NOT NULL, ADD from_countryCode VARCHAR(255) NOT NULL, ADD from_city VARCHAR(255) NOT NULL, ADD from_company VARCHAR(255) DEFAULT NULL, ADD from_provinceName VARCHAR(255) DEFAULT NULL, ADD from_provinceCode VARCHAR(255) DEFAULT NULL, ADD to_company VARCHAR(255) DEFAULT NULL, ADD to_taxId VARCHAR(255) DEFAULT NULL, ADD to_countryCode VARCHAR(255) DEFAULT NULL, ADD to_street VARCHAR(255) DEFAULT NULL, ADD to_city VARCHAR(255) DEFAULT NULL, ADD to_postcode VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema) : void

--- a/spec/Entity/CreditMemoSpec.php
+++ b/spec/Entity/CreditMemoSpec.php
@@ -8,8 +8,8 @@ use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Entity\CreditMemoChannel;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
 use Sylius\RefundPlugin\Entity\CreditMemoUnit;
-use Sylius\RefundPlugin\Model\CustomerBillingData;
-use Sylius\RefundPlugin\Model\ShopBillingData;
+use Sylius\RefundPlugin\Entity\CustomerBillingData;
+use Sylius\RefundPlugin\Entity\ShopBillingData;
 
 final class CreditMemoSpec extends ObjectBehavior
 {

--- a/spec/Entity/CreditMemoSpec.php
+++ b/spec/Entity/CreditMemoSpec.php
@@ -8,6 +8,8 @@ use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Entity\CreditMemoChannel;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
 use Sylius\RefundPlugin\Entity\CreditMemoUnit;
+use Sylius\RefundPlugin\Model\CustomerBillingData;
+use Sylius\RefundPlugin\Model\ShopBillingData;
 
 final class CreditMemoSpec extends ObjectBehavior
 {
@@ -25,7 +27,9 @@ final class CreditMemoSpec extends ObjectBehavior
             new CreditMemoChannel('WEB-US', 'United States', 'Linen'),
             [$creditMemoUnit->serialize()],
             'Comment',
-            new \DateTime('01-01-2020 10:10:10')
+            new \DateTime('01-01-2020 10:10:10'),
+            new CustomerBillingData('Rick Sanchez', 'Main St. 3322', '90802', 'US', 'Curse Purge Plus!', 'Los Angeles', 'Baldwin Hills', '323'),
+            new ShopBillingData('Needful Things', '000222', 'US', 'Main St. 123', 'Los Angeles', '90001')
         );
     }
 
@@ -82,5 +86,23 @@ final class CreditMemoSpec extends ObjectBehavior
     function it_has_comment(): void
     {
         $this->getComment()->shouldReturn('Comment');
+    }
+
+    function it_has_from_address(): void
+    {
+        $this
+            ->getFrom()
+            ->shouldBeLike(
+                new CustomerBillingData('Rick Sanchez', 'Main St. 3322', '90802', 'US', 'Curse Purge Plus!', 'Los Angeles', 'Baldwin Hills', '323')
+            )
+        ;
+    }
+
+    function it_has_to_address(): void
+    {
+        $this
+            ->getTo()
+            ->shouldBeLike(new ShopBillingData('Needful Things', '000222', 'US', 'Main St. 123', 'Los Angeles', '90001'))
+        ;
     }
 }

--- a/spec/Entity/CustomerBillingDataSpec.php
+++ b/spec/Entity/CustomerBillingDataSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Entity;
+
+use PhpSpec\ObjectBehavior;
+
+final class CustomerBillingDataSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith(
+            'Rick Sanchez',
+            'Main St. 3322',
+            '90802',
+            'US',
+            'Los Angeles',
+            'Curse Purge Plus!',
+            'Baldwin Hills',
+            '323'
+        );
+    }
+
+    function it_has_customer_name(): void
+    {
+        $this->customerName()->shouldReturn('Rick Sanchez');
+    }
+
+    function it_has_company(): void
+    {
+        $this->company()->shouldReturn('Curse Purge Plus!');
+    }
+
+    function it_has_street(): void
+    {
+        $this->street()->shouldReturn('Main St. 3322');
+    }
+
+    function it_has_postcode(): void
+    {
+        $this->postcode()->shouldReturn('90802');
+    }
+
+    function it_has_country_code(): void
+    {
+        $this->countryCode()->shouldReturn('US');
+    }
+
+    function it_has_city(): void
+    {
+        $this->city()->shouldReturn('Los Angeles');
+    }
+
+    function it_has_province_name(): void
+    {
+        $this->provinceName()->shouldReturn('Baldwin Hills');
+    }
+
+    function it_has_province_code(): void
+    {
+        $this->provinceCode()->shouldReturn('323');
+    }
+}

--- a/spec/Entity/ShopBillingDataSpec.php
+++ b/spec/Entity/ShopBillingDataSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Entity;
+
+use PhpSpec\ObjectBehavior;
+
+final class ShopBillingDataSpec extends ObjectBehavior
+{
+    function let(): void
+    {
+        $this->beConstructedWith('Needful Things', '000222', 'US', 'Main St. 123', 'Los Angeles', '90001');
+    }
+
+    function it_has_company(): void
+    {
+        $this->company()->shouldReturn('Needful Things');
+    }
+
+    function it_has_tax_id(): void
+    {
+        $this->taxId()->shouldReturn('000222');
+    }
+
+    function it_has_country_code(): void
+    {
+        $this->countryCode()->shouldReturn('US');
+    }
+
+    function it_has_street(): void
+    {
+        $this->street()->shouldReturn('Main St. 123');
+    }
+
+    function it_has_city(): void
+    {
+        $this->city()->shouldReturn('Los Angeles');
+    }
+
+    function it_has_postcode(): void
+    {
+        $this->postcode()->shouldReturn('90001');
+    }
+}

--- a/spec/Generator/CreditMemoGeneratorSpec.php
+++ b/spec/Generator/CreditMemoGeneratorSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\Sylius\RefundPlugin\Generator;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/spec/Generator/CreditMemoGeneratorSpec.php
+++ b/spec/Generator/CreditMemoGeneratorSpec.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace spec\Sylius\RefundPlugin\Generator;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShopBillingDataInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Entity\CreditMemo;
 use Sylius\RefundPlugin\Entity\CreditMemoChannel;
 use Sylius\RefundPlugin\Entity\CreditMemoUnit;
+use Sylius\RefundPlugin\Entity\CustomerBillingData;
+use Sylius\RefundPlugin\Entity\ShopBillingData;
 use Sylius\RefundPlugin\Exception\OrderNotFound;
 use Sylius\RefundPlugin\Generator\CreditMemoGeneratorInterface;
 use Sylius\RefundPlugin\Generator\CreditMemoIdentifierGeneratorInterface;
@@ -50,6 +55,8 @@ final class CreditMemoGeneratorSpec extends ObjectBehavior
         NumberGenerator $creditMemoNumberGenerator,
         OrderInterface $order,
         ChannelInterface $channel,
+        ShopBillingDataInterface $shopBillingData,
+        AddressInterface $customerBillingAddress,
         CreditMemoUnitGeneratorInterface $orderItemUnitCreditMemoUnitGenerator,
         CreditMemoUnitGeneratorInterface $shipmentCreditMemoUnitGenerator,
         CurrentDateTimeProviderInterface $currentDateTimeProvider,
@@ -68,6 +75,25 @@ final class CreditMemoGeneratorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('WEB-US');
         $channel->getName()->willReturn('United States');
         $channel->getColor()->willReturn('Linen');
+
+        $channel->getShopBillingData()->willReturn($shopBillingData);
+        $shopBillingData->getCompany()->willReturn('Needful Things');
+        $shopBillingData->getTaxId()->willReturn('000222');
+        $shopBillingData->getCountryCode()->willReturn('US');
+        $shopBillingData->getStreet()->willReturn('Main St. 123');
+        $shopBillingData->getCity()->willReturn('New York');
+        $shopBillingData->getPostcode()->willReturn('90222');
+
+        $order->getBillingAddress()->willReturn($customerBillingAddress);
+        $customerBillingAddress->getFirstName()->willReturn('Rick');
+        $customerBillingAddress->getLastName()->willReturn('Sanchez');
+        $customerBillingAddress->getPostcode()->willReturn('000333');
+        $customerBillingAddress->getCountryCode()->willReturn('US');
+        $customerBillingAddress->getStreet()->willReturn('Universe St. 444');
+        $customerBillingAddress->getCity()->willReturn('Los Angeles');
+        $customerBillingAddress->getCompany()->willReturn('Curse Purge Plus!');
+        $customerBillingAddress->getProvinceName()->willReturn(null);
+        $customerBillingAddress->getProvinceCode()->willReturn(null);
 
         $firstCreditMemoUnit = new CreditMemoUnit('Portal gun', 500, 50);
         $orderItemUnitCreditMemoUnitGenerator->generate(1, 500)->willReturn($firstCreditMemoUnit);
@@ -98,7 +124,9 @@ final class CreditMemoGeneratorSpec extends ObjectBehavior
                 $shipmentCreditMemoUnit->serialize(),
             ],
             'Comment',
-            $dateTime->getWrappedObject()
+            $dateTime->getWrappedObject(),
+            new CustomerBillingData('Rick Sanchez', 'Universe St. 444', '000333', 'US', 'Los Angeles', 'Curse Purge Plus!'),
+            new ShopBillingData('Needful Things', '000222', 'US', 'Main St. 123', 'New York', '90222')
         ));
     }
 

--- a/src/Entity/CreditMemo.php
+++ b/src/Entity/CreditMemo.php
@@ -40,7 +40,7 @@ class CreditMemo implements CreditMemoInterface
     /** @var CustomerBillingData */
     private $from;
 
-    /** @var ShopBillingData */
+    /** @var ShopBillingData|null */
     private $to;
 
     public function __construct(
@@ -55,7 +55,7 @@ class CreditMemo implements CreditMemoInterface
         string $comment,
         \DateTimeInterface $issuedAt,
         CustomerBillingData $from,
-        ShopBillingData $to
+        ?ShopBillingData $to
     ) {
         $this->id = $id;
         $this->number = $number;
@@ -131,7 +131,7 @@ class CreditMemo implements CreditMemoInterface
         return $this->from;
     }
 
-    public function getTo(): ShopBillingData
+    public function getTo(): ?ShopBillingData
     {
         return $this->to;
     }

--- a/src/Entity/CreditMemo.php
+++ b/src/Entity/CreditMemo.php
@@ -37,6 +37,12 @@ class CreditMemo implements CreditMemoInterface
     /** @var \DateTimeInterface */
     private $issuedAt;
 
+    /** @var CustomerBillingData */
+    private $from;
+
+    /** @var ShopBillingData */
+    private $to;
+
     public function __construct(
         string $id,
         string $number,
@@ -47,7 +53,9 @@ class CreditMemo implements CreditMemoInterface
         CreditMemoChannel $channel,
         array $units,
         string $comment,
-        \DateTimeInterface $issuedAt
+        \DateTimeInterface $issuedAt,
+        CustomerBillingData $from,
+        ShopBillingData $to
     ) {
         $this->id = $id;
         $this->number = $number;
@@ -59,6 +67,8 @@ class CreditMemo implements CreditMemoInterface
         $this->units = $units;
         $this->comment = $comment;
         $this->issuedAt = $issuedAt;
+        $this->from = $from;
+        $this->to = $to;
     }
 
     public function getId(): string
@@ -114,5 +124,15 @@ class CreditMemo implements CreditMemoInterface
     public function getIssuedAt(): \DateTimeInterface
     {
         return $this->issuedAt;
+    }
+
+    public function getFrom(): CustomerBillingData
+    {
+        return $this->from;
+    }
+
+    public function getTo(): ShopBillingData
+    {
+        return $this->to;
     }
 }

--- a/src/Entity/CreditMemoInterface.php
+++ b/src/Entity/CreditMemoInterface.php
@@ -28,5 +28,5 @@ interface CreditMemoInterface extends ResourceInterface
 
     public function getFrom(): CustomerBillingData;
 
-    public function getTo(): ShopBillingData;
+    public function getTo(): ?ShopBillingData;
 }

--- a/src/Entity/CreditMemoInterface.php
+++ b/src/Entity/CreditMemoInterface.php
@@ -25,4 +25,8 @@ interface CreditMemoInterface extends ResourceInterface
     public function getComment(): string;
 
     public function getIssuedAt(): \DateTimeInterface;
+
+    public function getFrom(): CustomerBillingData;
+
+    public function getTo(): ShopBillingData;
 }

--- a/src/Entity/CustomerBillingData.php
+++ b/src/Entity/CustomerBillingData.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Entity;
+
+final class CustomerBillingData
+{
+    /** @var string */
+    private $customerName;
+
+    /** @var string */
+    private $street;
+
+    /** @var string */
+    private $postcode;
+
+    /** @var string */
+    private $countryCode;
+
+    /** @var string */
+    private $city;
+
+    /** @var string|null */
+    private $company;
+
+    /** @var string|null */
+    private $provinceName;
+
+    /** @var string|null */
+    private $provinceCode;
+
+    public function __construct(
+        string $customerName,
+        string $street,
+        string $postcode,
+        string $countryCode,
+        string $city,
+        ?string $company = null,
+        ?string $provinceName = null,
+        ?string $provinceCode = null
+    ) {
+        $this->customerName = $customerName;
+        $this->street = $street;
+        $this->postcode = $postcode;
+        $this->countryCode = $countryCode;
+        $this->city = $city;
+        $this->company = $company;
+        $this->provinceName = $provinceName;
+        $this->provinceCode = $provinceCode;
+    }
+
+    public function customerName(): string
+    {
+        return $this->customerName;
+    }
+
+    public function street(): string
+    {
+        return $this->street;
+    }
+
+    public function postcode(): string
+    {
+        return $this->postcode;
+    }
+
+    public function countryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function city(): string
+    {
+        return $this->city;
+    }
+
+    public function company(): ?string
+    {
+        return $this->company;
+    }
+
+    public function provinceName(): ?string
+    {
+        return $this->provinceName;
+    }
+
+    public function provinceCode(): ?string
+    {
+        return $this->provinceCode;
+    }
+}

--- a/src/Entity/ShopBillingData.php
+++ b/src/Entity/ShopBillingData.php
@@ -6,31 +6,31 @@ namespace Sylius\RefundPlugin\Entity;
 
 final class ShopBillingData
 {
-    /** @var string */
+    /** @var string|null */
     private $company;
 
-    /** @var string */
+    /** @var string|null */
     private $taxId;
 
-    /** @var string */
+    /** @var string|null */
     private $countryCode;
 
-    /** @var string */
+    /** @var string|null */
     private $street;
 
-    /** @var string */
+    /** @var string|null */
     private $city;
 
-    /** @var string */
+    /** @var string|null */
     private $postcode;
 
     public function __construct(
-        string $company,
-        string $taxId,
-        string $countryCode,
-        string $street,
-        string $city,
-        string $postcode
+        ?string $company,
+        ?string $taxId,
+        ?string $countryCode,
+        ?string $street,
+        ?string $city,
+        ?string $postcode
     ) {
         $this->company = $company;
         $this->taxId = $taxId;
@@ -40,32 +40,32 @@ final class ShopBillingData
         $this->postcode = $postcode;
     }
 
-    public function company(): string
+    public function company(): ?string
     {
         return $this->company;
     }
 
-    public function taxId(): string
+    public function taxId(): ?string
     {
         return $this->taxId;
     }
 
-    public function countryCode(): string
+    public function countryCode(): ?string
     {
         return $this->countryCode;
     }
 
-    public function street(): string
+    public function street(): ?string
     {
         return $this->street;
     }
 
-    public function city(): string
+    public function city(): ?string
     {
         return $this->city;
     }
 
-    public function postcode(): string
+    public function postcode(): ?string
     {
         return $this->postcode;
     }

--- a/src/Entity/ShopBillingData.php
+++ b/src/Entity/ShopBillingData.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Entity;
+
+final class ShopBillingData
+{
+    /** @var string */
+    private $company;
+
+    /** @var string */
+    private $taxId;
+
+    /** @var string */
+    private $countryCode;
+
+    /** @var string */
+    private $street;
+
+    /** @var string */
+    private $city;
+
+    /** @var string */
+    private $postcode;
+
+    public function __construct(
+        string $company,
+        string $taxId,
+        string $countryCode,
+        string $street,
+        string $city,
+        string $postcode
+    ) {
+        $this->company = $company;
+        $this->taxId = $taxId;
+        $this->countryCode = $countryCode;
+        $this->street = $street;
+        $this->city = $city;
+        $this->postcode = $postcode;
+    }
+
+    public function company(): string
+    {
+        return $this->company;
+    }
+
+    public function taxId(): string
+    {
+        return $this->taxId;
+    }
+
+    public function countryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function street(): string
+    {
+        return $this->street;
+    }
+
+    public function city(): string
+    {
+        return $this->city;
+    }
+
+    public function postcode(): string
+    {
+        return $this->postcode;
+    }
+}

--- a/src/Generator/CreditMemoGenerator.php
+++ b/src/Generator/CreditMemoGenerator.php
@@ -118,8 +118,15 @@ final class CreditMemoGenerator implements CreditMemoGeneratorInterface
         );
     }
 
-    private function getToAddress(ChannelShopBillingData $channelShopBillingData): ShopBillingData
+    private function getToAddress(?ChannelShopBillingData $channelShopBillingData): ?ShopBillingData
     {
+        if (
+            $channelShopBillingData === null ||
+            ($channelShopBillingData->getStreet() === null && $channelShopBillingData->getCompany() === null)
+        ) {
+            return null;
+        }
+
         return new ShopBillingData(
             $channelShopBillingData->getCompany(),
             $channelShopBillingData->getTaxId(),

--- a/src/Generator/CreditMemoGenerator.php
+++ b/src/Generator/CreditMemoGenerator.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Generator;
 
+use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShopBillingDataInterface as ChannelShopBillingData;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Entity\CreditMemo;
 use Sylius\RefundPlugin\Entity\CreditMemoChannel;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
+use Sylius\RefundPlugin\Entity\CustomerBillingData;
+use Sylius\RefundPlugin\Entity\ShopBillingData;
 use Sylius\RefundPlugin\Exception\OrderNotFound;
 use Sylius\RefundPlugin\Model\UnitRefundInterface;
 use Sylius\RefundPlugin\Provider\CurrentDateTimeProviderInterface;
@@ -94,7 +98,35 @@ final class CreditMemoGenerator implements CreditMemoGeneratorInterface
             new CreditMemoChannel($channel->getCode(), $channel->getName(), $channel->getColor()),
             $creditMemoUnits,
             $comment,
-            $this->currentDateTimeProvider->now()
+            $this->currentDateTimeProvider->now(),
+            $this->getFromAddress($order->getBillingAddress()),
+            $this->getToAddress($channel->getShopBillingData())
+        );
+    }
+
+    private function getFromAddress(AddressInterface $address): CustomerBillingData
+    {
+        return new CustomerBillingData(
+            $address->getFirstName() . ' ' . $address->getLastName(),
+            $address->getStreet(),
+            $address->getPostcode(),
+            $address->getCountryCode(),
+            $address->getCity(),
+            $address->getCompany(),
+            $address->getProvinceName(),
+            $address->getProvinceCode()
+        );
+    }
+
+    private function getToAddress(ChannelShopBillingData $channelShopBillingData): ShopBillingData
+    {
+        return new ShopBillingData(
+            $channelShopBillingData->getCompany(),
+            $channelShopBillingData->getTaxId(),
+            $channelShopBillingData->getCountryCode(),
+            $channelShopBillingData->getStreet(),
+            $channelShopBillingData->getCity(),
+            $channelShopBillingData->getPostcode()
         );
     }
 }

--- a/src/Resources/config/doctrine/CreditMemo.orm.xml
+++ b/src/Resources/config/doctrine/CreditMemo.orm.xml
@@ -20,6 +20,8 @@
         <field name="issuedAt" column="issued_at" type="datetime" nullable="true" />
 
         <embedded name="channel" class="Sylius\RefundPlugin\Entity\CreditMemoChannel" />
+        <embedded name="from" class="Sylius\RefundPlugin\Entity\CustomerBillingData" />
+        <embedded name="to" class="Sylius\RefundPlugin\Entity\ShopBillingData" />
 
         <indexes>
             <index columns="orderNumber" />

--- a/src/Resources/config/doctrine/CustomerBillingData.orm.xml
+++ b/src/Resources/config/doctrine/CustomerBillingData.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+    <embeddable name="Sylius\RefundPlugin\Entity\CustomerBillingData">
+        <field name="customerName" />
+        <field name="street" />
+        <field name="postcode" />
+        <field name="countryCode" />
+        <field name="city" />
+        <field name="company" nullable="true" />
+        <field name="provinceName" nullable="true" />
+        <field name="provinceCode" nullable="true" />
+    </embeddable>
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/ShopBillingData.orm.xml
+++ b/src/Resources/config/doctrine/ShopBillingData.orm.xml
@@ -7,11 +7,11 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
     <embeddable name="Sylius\RefundPlugin\Entity\ShopBillingData">
-        <field name="company" />
-        <field name="taxId" />
-        <field name="countryCode" />
-        <field name="street" />
-        <field name="city" />
-        <field name="postcode" />
+        <field name="company" nullable="true" />
+        <field name="taxId" nullable="true" />
+        <field name="countryCode" nullable="true" />
+        <field name="street" nullable="true" />
+        <field name="city" nullable="true" />
+        <field name="postcode" nullable="true" />
     </embeddable>
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/ShopBillingData.orm.xml
+++ b/src/Resources/config/doctrine/ShopBillingData.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+    <embeddable name="Sylius\RefundPlugin\Entity\ShopBillingData">
+        <field name="company" />
+        <field name="taxId" />
+        <field name="countryCode" />
+        <field name="street" />
+        <field name="city" />
+        <field name="postcode" />
+    </embeddable>
+</doctrine-mapping>

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -4,6 +4,7 @@ sylius_refund:
         credit_memo: Credit memo
         credit_memos: Credit memos
         download: Download
+        from: From
         issued_at: Issued at
         issued_for_order: Issued for order
         issued_from: Issued from
@@ -16,6 +17,7 @@ sylius_refund:
         refunded: Refunded
         refunded_total: Refunded total
         refunds: Refunds
+        to: To
 
 sylius:
     ui:

--- a/src/Resources/views/Download/creditMemo.html.twig
+++ b/src/Resources/views/Download/creditMemo.html.twig
@@ -10,37 +10,42 @@
 <h1>{{ 'sylius_refund.ui.credit_memo'|trans }} #{{ creditMemo.number }}</h1>
 <p>{{ 'sylius_refund.ui.order_number'|trans }}: #{{ creditMemo.orderNumber }}</p>
 
-<br /><br />
-
-<p>
-    {% set from = creditMemo.from %}
-    <h4>{{ 'sylius_refund.ui.from'|trans }}</h4>
-    <address>
-        <strong>{{ from.customerName }}</strong>
-        {% if from.company %}
-            {{ from.company }}
-        {% endif %}
-        <br/>{{ from.street }}<br/>
-        {{ from.city }}<br/>
-        {% if from.provinceName is not empty %}
-            {{ from.provinceName }}<br/>
-        {% endif %}
-        <i class="{{ from.countryCode|lower }} flag"></i>
-        {{ from.countryCode|sylius_country_name|upper }} {{ from.postcode }}
-    </address>
-</p>
-<p>
-    {% set to = creditMemo.to %}
-    <h4>{{ 'sylius_refund.ui.to'|trans }}</h4>
-    <address>
-        <strong>{{ to.company }}</strong>
-        {{ to.taxId }}<br/>
-        {{ to.city }}<br/>
-        {{ to.street }}<br/>
-        <i class="{{ to.countryCode|lower }} flag"></i>
-        {{ to.countryCode|sylius_country_name|upper }} {{ to.postcode }}
-    </address>
-</p>
+{% if creditMemo.from != null or creditMemo.to != null %}
+    <br /><br />
+    {% if creditMemo.from != null %}
+    <p>
+        {% set from = creditMemo.from %}
+        <h4>{{ 'sylius_refund.ui.from'|trans }}</h4>
+        <address>
+            <strong>{{ from.customerName }}</strong>
+            {% if from.company %}
+                {{ from.company }}
+            {% endif %}
+            <br/>{{ from.street }}<br/>
+            {{ from.city }}<br/>
+            {% if from.provinceName is not empty %}
+                {{ from.provinceName }}<br/>
+            {% endif %}
+            <i class="{{ from.countryCode|lower }} flag"></i>
+            {{ from.countryCode|sylius_country_name|upper }} {{ from.postcode }}
+        </address>
+    </p>
+    {% endif %}
+    {% if creditMemo.to != null and creditMemo.to.taxId != null %}
+    <p>
+        {% set to = creditMemo.to %}
+        <h4>{{ 'sylius_refund.ui.to'|trans }}</h4>
+        <address>
+            <strong>{{ to.company }}</strong>
+            {{ to.taxId }}<br/>
+            {{ to.city }}<br/>
+            {{ to.street }}<br/>
+            <i class="{{ to.countryCode|lower }} flag"></i>
+            {{ to.countryCode|sylius_country_name|upper }} {{ to.postcode }}
+        </address>
+    </p>
+    {% endif %}
+{% endif %}
 
 <table>
     <thead>

--- a/src/Resources/views/Download/creditMemo.html.twig
+++ b/src/Resources/views/Download/creditMemo.html.twig
@@ -12,6 +12,36 @@
 
 <br /><br />
 
+<p>
+    {% set from = creditMemo.from %}
+    <h4>{{ 'sylius_refund.ui.from'|trans }}</h4>
+    <address>
+        <strong>{{ from.customerName }}</strong>
+        {% if from.company %}
+            {{ from.company }}
+        {% endif %}
+        <br/>{{ from.street }}<br/>
+        {{ from.city }}<br/>
+        {% if from.provinceName is not empty %}
+            {{ from.provinceName }}<br/>
+        {% endif %}
+        <i class="{{ from.countryCode|lower }} flag"></i>
+        {{ from.countryCode|sylius_country_name|upper }} {{ from.postcode }}
+    </address>
+</p>
+<p>
+    {% set to = creditMemo.to %}
+    <h4>{{ 'sylius_refund.ui.to'|trans }}</h4>
+    <address>
+        <strong>{{ to.company }}</strong>
+        {{ to.taxId }}<br/>
+        {{ to.city }}<br/>
+        {{ to.street }}<br/>
+        <i class="{{ to.countryCode|lower }} flag"></i>
+        {{ to.countryCode|sylius_country_name|upper }} {{ to.postcode }}
+    </address>
+</p>
+
 <table>
     <thead>
     <tr>

--- a/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
+++ b/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
@@ -24,7 +24,7 @@
 
     <div class="ui stackable grid">
         <div class="eight wide column">
-            <h4 class="ui top attached styled header">From</h4>
+            <h4 class="ui top attached styled header">{{ 'sylius_refund.ui.from'|trans }}</h4>
             <div class="ui attached segment" id="from-address">
                 {% set from = credit_memo.from %}
                 <address>
@@ -43,7 +43,7 @@
             </div>
         </div>
         <div class="eight wide column">
-            <h4 class="ui top attached styled header">To</h4>
+            <h4 class="ui top attached styled header">{{ 'sylius_refund.ui.to'|trans }}</h4>
             <div class="ui attached segment" id="to-address">
                 {% set to = credit_memo.to %}
                 <address>

--- a/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
+++ b/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
@@ -22,6 +22,43 @@
         </div>
     </div>
 
+    <div class="ui stackable grid">
+        <div class="eight wide column">
+            <h4 class="ui top attached styled header">From</h4>
+            <div class="ui attached segment" id="from-address">
+                {% set from = credit_memo.from %}
+                <address>
+                    <strong>{{ from.customerName }}</strong>
+                    {% if from.company %}
+                        {{ from.company }}
+                    {% endif %}
+                    <br/>{{ from.street }}<br/>
+                    {{ from.city }}<br/>
+                    {% if from.provinceName is not empty %}
+                        {{ from.provinceName }}<br/>
+                    {% endif %}
+                    <i class="{{ from.countryCode|lower }} flag"></i>
+                    {{ from.countryCode|sylius_country_name|upper }} {{ from.postcode }}
+                </address>
+            </div>
+        </div>
+        <div class="eight wide column">
+            <h4 class="ui top attached styled header">To</h4>
+            <div class="ui attached segment" id="to-address">
+                {% set to = credit_memo.to %}
+                <address>
+                    <strong>{{ to.company }}</strong>
+                    {{ to.taxId }}<br/>
+                    {{ to.city }}<br/>
+                    {{ to.street }}<br/>
+                    <i class="{{ to.countryCode|lower }} flag"></i>
+                    {{ to.countryCode|sylius_country_name|upper }} {{ to.postcode }}
+                </address>
+            </div>
+        </div>
+        </div>
+    </div>
+
     <div class="ui stackable segment grid">
         <div class="sixteen wide column">
             <table class="ui celled compact small table fixed">

--- a/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
+++ b/src/Resources/views/Order/Admin/CreditMemo/details.html.twig
@@ -21,8 +21,9 @@
             ) }}
         </div>
     </div>
-
+    {% if credit_memo.from != null or credit_memo.to != null %}
     <div class="ui stackable grid">
+        {% if credit_memo.from != null %}
         <div class="eight wide column">
             <h4 class="ui top attached styled header">{{ 'sylius_refund.ui.from'|trans }}</h4>
             <div class="ui attached segment" id="from-address">
@@ -42,6 +43,8 @@
                 </address>
             </div>
         </div>
+        {% endif %}
+        {% if credit_memo.to != null and credit_memo.to.taxId != null %}
         <div class="eight wide column">
             <h4 class="ui top attached styled header">{{ 'sylius_refund.ui.to'|trans }}</h4>
             <div class="ui attached segment" id="to-address">
@@ -56,9 +59,9 @@
                 </address>
             </div>
         </div>
-        </div>
+        {% endif %}
     </div>
-
+    {% endif %}
     <div class="ui stackable segment grid">
         <div class="sixteen wide column">
             <table class="ui celled compact small table fixed">

--- a/tests/Application/config/packages/test/knp_snappy.yaml
+++ b/tests/Application/config/packages/test/knp_snappy.yaml
@@ -1,3 +1,3 @@
-knp_snappy:
-    pdf:
-        binary: "%kernel.project_dir%/etc/wkhtmltopdf"
+#knp_snappy:
+#    pdf:
+#        binary: "%kernel.project_dir%/etc/wkhtmltopdf"

--- a/tests/Application/config/packages/test/knp_snappy.yaml
+++ b/tests/Application/config/packages/test/knp_snappy.yaml
@@ -1,3 +1,3 @@
-#knp_snappy:
-#    pdf:
-#        binary: "%kernel.project_dir%/etc/wkhtmltopdf"
+knp_snappy:
+    pdf:
+        binary: "%kernel.project_dir%/etc/wkhtmltopdf"

--- a/tests/Behat/Context/Application/CreditMemoContext.php
+++ b/tests/Behat/Context/Application/CreditMemoContext.php
@@ -7,6 +7,7 @@ namespace Tests\Sylius\RefundPlugin\Behat\Context\Application;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Tester\Exception\PendingException;
 use Doctrine\Common\Persistence\ObjectRepository;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
 use Sylius\RefundPlugin\Provider\CurrentDateTimeProviderInterface;
 use Webmozart\Assert\Assert;
@@ -111,5 +112,31 @@ final class CreditMemoContext implements Context
     public function itShouldBeCommentedWith(string $comment): void
     {
         Assert::same($this->creditMemo->getComment(), $comment);
+    }
+
+    /**
+     * @Then it should be issued from :customerName, :street, :postcode :city in the :country
+     */
+    public function itShouldBeIssuedFrom(
+        string $customerName,
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void {
+        throw new PendingException();
+    }
+
+    /**
+     * @Then it should be issued to :company, :street, :postcode :city in the :country
+     */
+    public function itShouldBeIssuedTo(
+        string $company,
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void {
+        throw new PendingException();
     }
 }

--- a/tests/Behat/Context/Application/CreditMemoContext.php
+++ b/tests/Behat/Context/Application/CreditMemoContext.php
@@ -126,7 +126,7 @@ final class CreditMemoContext implements Context
         string $city,
         CountryInterface $country
     ): void {
-        Assert::same(
+        Assert::eq(
             $this->creditMemo->getFrom(),
             new CustomerBillingData($customerName, $street, $postcode, $country->getCode(), $city)
         );
@@ -143,7 +143,7 @@ final class CreditMemoContext implements Context
         CountryInterface $country,
         string $taxId
     ): void {
-        Assert::same(
+        Assert::eq(
             $this->creditMemo->getTo(),
             new ShopBillingData($company, $taxId, $country->getCode(), $street, $city, $postcode)
         );

--- a/tests/Behat/Context/Application/CreditMemoContext.php
+++ b/tests/Behat/Context/Application/CreditMemoContext.php
@@ -9,6 +9,8 @@ use Behat\Behat\Tester\Exception\PendingException;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
+use Sylius\RefundPlugin\Entity\CustomerBillingData;
+use Sylius\RefundPlugin\Entity\ShopBillingData;
 use Sylius\RefundPlugin\Provider\CurrentDateTimeProviderInterface;
 use Webmozart\Assert\Assert;
 
@@ -124,19 +126,26 @@ final class CreditMemoContext implements Context
         string $city,
         CountryInterface $country
     ): void {
-        throw new PendingException();
+        Assert::same(
+            $this->creditMemo->getFrom(),
+            new CustomerBillingData($customerName, $street, $postcode, $country->getCode(), $city)
+        );
     }
 
     /**
-     * @Then it should be issued to :company, :street, :postcode :city in the :country
+     * @Then it should be issued to :company, :street, :postcode :city in the :country with :taxId tax ID
      */
     public function itShouldBeIssuedTo(
         string $company,
         string $street,
         string $postcode,
         string $city,
-        CountryInterface $country
+        CountryInterface $country,
+        string $taxId
     ): void {
-        throw new PendingException();
+        Assert::same(
+            $this->creditMemo->getTo(),
+            new ShopBillingData($company, $taxId, $country->getCode(), $street, $city, $postcode)
+        );
     }
 }

--- a/tests/Behat/Context/Setup/ChannelContext.php
+++ b/tests/Behat/Context/Setup/ChannelContext.php
@@ -7,7 +7,10 @@ namespace Tests\Sylius\RefundPlugin\Behat\Context\Setup;
 use Behat\Behat\Context\Context;
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ShopBillingData;
 use Sylius\Component\Core\Test\Services\DefaultChannelFactoryInterface;
 
 final class ChannelContext implements Context
@@ -60,6 +63,30 @@ final class ChannelContext implements Context
 
         $this->sharedStorage->setClipboard($defaultData);
         $this->sharedStorage->set('channel', $defaultData['channel']);
+        $this->channelManager->flush();
+    }
+
+    /**
+     * @Given channel :channel billing data is :company, :street, :postcode :city, :country with :taxId tax ID
+     */
+    public function channelBillingDataIs(
+        ChannelInterface $channel,
+        string $company,
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country,
+        string $taxId
+    ): void {
+        $shopBillingData = new ShopBillingData();
+        $shopBillingData->setCompany($company);
+        $shopBillingData->setStreet($street);
+        $shopBillingData->setPostcode($postcode);
+        $shopBillingData->setCity($city);
+        $shopBillingData->setCountryCode($country->getCode());
+        $shopBillingData->setTaxId($taxId);
+
+        $channel->setShopBillingData($shopBillingData);
         $this->channelManager->flush();
     }
 }

--- a/tests/Behat/Context/Ui/CreditMemoContext.php
+++ b/tests/Behat/Context/Ui/CreditMemoContext.php
@@ -8,6 +8,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Tester\Exception\PendingException;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\RefundPlugin\Entity\CreditMemoInterface;
 use Sylius\RefundPlugin\Provider\CurrentDateTimeProviderInterface;
@@ -154,6 +155,32 @@ final class CreditMemoContext implements Context
     public function creditMemoShouldBeIssuedInChannel(string $channelName): void
     {
         Assert::same($this->creditMemoDetailsPage->getChannelName(), $channelName);
+    }
+
+    /**
+     * @Then it should be issued from :customerName, :street, :postcode :city in the :country
+     */
+    public function itShouldBeIssuedFrom(
+        string $customerName,
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void {
+        throw new PendingException();
+    }
+
+    /**
+     * @Then it should be issued to :company, :street, :postcode :city in the :country
+     */
+    public function itShouldBeIssuedTo(
+        string $company,
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void {
+        throw new PendingException();
     }
 
     /**

--- a/tests/Behat/Context/Ui/CreditMemoContext.php
+++ b/tests/Behat/Context/Ui/CreditMemoContext.php
@@ -167,20 +167,27 @@ final class CreditMemoContext implements Context
         string $city,
         CountryInterface $country
     ): void {
-        throw new PendingException();
+        Assert::same(
+            $this->creditMemoDetailsPage->getFromAddress(),
+            $customerName . ' ' . $street . ' ' . $city . ' ' . strtoupper($country->getName()) . ' ' . $postcode
+        );
     }
 
     /**
-     * @Then it should be issued to :company, :street, :postcode :city in the :country
+     * @Then it should be issued to :company, :street, :postcode :city in the :country with :taxId tax ID
      */
     public function itShouldBeIssuedTo(
         string $company,
         string $street,
         string $postcode,
         string $city,
-        CountryInterface $country
+        CountryInterface $country,
+        string $taxId
     ): void {
-        throw new PendingException();
+        Assert::same(
+            $this->creditMemoDetailsPage->getToAddress(),
+            $company . ' ' . $taxId . ' ' . $city . ' ' . $street . ' ' . strtoupper($country->getName()) . ' ' . $postcode
+        );
     }
 
     /**

--- a/tests/Behat/Page/Admin/CreditMemoDetailsPage.php
+++ b/tests/Behat/Page/Admin/CreditMemoDetailsPage.php
@@ -58,6 +58,16 @@ final class CreditMemoDetailsPage extends SymfonyPage implements CreditMemoDetai
         return $this->getDocument()->find('css', '#credit-memo-comment')->getText();
     }
 
+    public function getFromAddress(): string
+    {
+        return $this->getDocument()->find('css', '#from-address')->getText();
+    }
+
+    public function getToAddress(): string
+    {
+        return $this->getDocument()->find('css', '#to-address')->getText();
+    }
+
     /** @return array|NodeElement[] */
     private function getCreditMemoUnitsWithProduct(string $productName): array
     {

--- a/tests/Behat/Page/Admin/CreditMemoDetailsPageInterface.php
+++ b/tests/Behat/Page/Admin/CreditMemoDetailsPageInterface.php
@@ -23,4 +23,8 @@ interface CreditMemoDetailsPageInterface extends SymfonyPageInterface
     public function getTotal(): string;
 
     public function getComment(): string;
+
+    public function getFromAddress(): string;
+
+    public function getToAddress(): string;
 }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -49,6 +49,8 @@ default:
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.customer
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.order


### PR DESCRIPTION
For now, credit memo was a little bit trivial document, with the obvious need of customization, as it didn't even contain any data (neither customer nor shop billing address). This PR introduces these 2 sets of data and display them on both credit memo show page and credit memo pdf document. "From" is obviously a customer billing address taken from the order, "to" is a shop billing data (it's in Sylius Core since `1.4`).

Fixes https://github.com/Sylius/RefundPlugin/issues/106

<img width="1180" alt="zrzut ekranu 2019-02-15 o 16 30 30" src="https://user-images.githubusercontent.com/6212718/52901990-dc624400-320a-11e9-9258-8c472a873bb4.png">

<img width="758" alt="zrzut ekranu 2019-02-15 o 16 30 14" src="https://user-images.githubusercontent.com/6212718/52901995-df5d3480-320a-11e9-82f2-7364bdcbfe69.png">
