### PR TITLE
Better tests coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 
 .env.test
 
-coverage/
+phpspec.yml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /tests/Application/yarn.lock
 
 .env.test
+
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,28 @@ jobs:
                 - composer analyse
 
                 - vendor/bin/phpunit
-                - vendor/bin/phpspec run
                 - vendor/bin/behat --strict -vvv --no-interaction --tags="~@todo" || vendor/bin/behat --strict -vvv --no-interaction --rerun --tags="~@todo"
 
             after_failure:
                 - vendor/lakion/mink-debug-extension/travis/tools/upload-textfiles "${SYLIUS_BUILD_DIR}/*.log"s
+
+        -
+            stage: test
+            name: "PHPSpec (with code coverage)"
+
+            sudo: false
+
+            services:
+                - memcached
+
+            before_install:
+                - phpenv config-rm xdebug.ini || true
+
+                - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+                - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+            install:
+                - composer update --no-interaction --prefer-dist
+
+            script:
+                - phpdbg -qrr vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "friends-of-behat/symfony-extension": "^2.0",
         "friends-of-behat/variadic-extension": "^1.1",
         "lakion/mink-debug-extension": "^1.2.3",
+        "leanphp/phpspec-code-coverage": "^4.2",
         "phpspec/phpspec": "^4.0",
         "phpstan/phpstan-shim": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10.0",

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -6,16 +6,16 @@ suites:
 extensions:
     LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
         blacklist:
-            - src/Action
-            - src/DependencyInjection
-            - src/Entity
-            - src/File/TemporaryFileManager.php
-            - src/Form
-            - src/Menu
-            - src/StateResolver/OrderTransitions.php
-            - src/StateResolver/RefundPaymentTransitions.php
-            - src/SyliusRefundPlugin.php
-            - src/Twig
+            - src/Action #controllers should not be unit tests, as they only translates request to response (with some operations in the meantime)
+            - src/DependencyInjection #configuration
+            - src/Entity #anemic classes with no logic
+            - src/File/TemporaryFileManager.php #covered with phpunit
+            - src/Form #builders, no value in testing them
+            - src/Menu #builders, no value in testing them
+            - src/StateResolver/OrderTransitions.php #only constants
+            - src/StateResolver/RefundPaymentTransitions.php #only constants
+            - src/SyliusRefundPlugin.php #configuration
+            - src/Twig #covered with behat (strictly UI-oriented classes)
         format:
             - text
         lower_upper_bound: 95

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -2,3 +2,21 @@ suites:
     sylius_refund:
         namespace: Sylius\RefundPlugin
         psr4_prefix: Sylius\RefundPlugin
+
+extensions:
+    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
+        blacklist:
+            - src/Action
+            - src/DependencyInjection
+            - src/Entity
+            - src/File/TemporaryFileManager.php
+            - src/Form
+            - src/Menu
+            - src/StateResolver/OrderTransitions.php
+            - src/StateResolver/RefundPaymentTransitions.php
+            - src/SyliusRefundPlugin.php
+            - src/Twig
+        format:
+            - text
+        lower_upper_bound: 95
+        high_lower_bound: 100

--- a/spec/Grid/Filter/ChannelFilterSpec.php
+++ b/spec/Grid/Filter/ChannelFilterSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Grid\Filter;
+
+use Doctrine\ORM\Query\Expr\Comparison;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
+
+final class ChannelFilterSpec extends ObjectBehavior
+{
+    function it_does_nothing_if_channel_is_not_defined(
+        DataSourceInterface $dataSource
+    ): void {
+        $dataSource->restrict(Argument::any())->shouldNotBeCalled();
+
+        $this->apply($dataSource, 'test', ['channel' => ''], []);
+    }
+
+    function it_restricts_data_for_specific_channel(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder,
+        Comparison $comparison
+    ): void {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+        $expressionBuilder->equals('o.channel.code', 'DEFAULT')->willReturn($comparison);
+
+        $dataSource->restrict($comparison)->shouldBeCalled();
+
+        $this->apply($dataSource, 'test', ['channel' => 'DEFAULT'], []);
+    }
+}

--- a/spec/Listener/CreditMemoGeneratedEventListenerSpec.php
+++ b/spec/Listener/CreditMemoGeneratedEventListenerSpec.php
@@ -44,6 +44,23 @@ final class CreditMemoGeneratedEventListenerSpec extends ObjectBehavior
         $this->__invoke(new CreditMemoGenerated('2018/04/00001111', '000000001'));
     }
 
+    function it_throws_exception_if_credit_memo_order_has_no_customer(
+        RepositoryInterface $creditMemoRepository,
+        OrderRepositoryInterface $orderRepository,
+        CreditMemoInterface $creditMemo,
+        OrderInterface $order
+    ): void {
+        $creditMemoRepository->findOneBy(['number' => '2018/04/00001111'])->willReturn($creditMemo);
+        $orderRepository->findOneByNumber('000000001')->willReturn($order);
+
+        $order->getCustomer()->willReturn(null);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('__invoke', [new CreditMemoGenerated('2018/04/00001111', '000000001')])
+        ;
+    }
+
     function it_throws_exception_if_there_is_no_credit_memo_with_given_number(
         RepositoryInterface $creditMemoRepository
     ): void {

--- a/spec/Model/RefundTypeSpec.php
+++ b/spec/Model/RefundTypeSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Model;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\RefundPlugin\Exception\RefundTypeNotResolved;
+use Sylius\RefundPlugin\Model\RefundType;
+
+final class RefundTypeSpec extends ObjectBehavior
+{
+    function it_can_be_order_item_unit_type(): void
+    {
+        $this->beConstructedThrough('orderItemUnit');
+        $this->__toString()->shouldReturn(RefundType::ORDER_ITEM_UNIT);
+    }
+
+    function it_can_be_shipment_type(): void
+    {
+        $this->beConstructedThrough('shipment');
+        $this->__toString()->shouldReturn(RefundType::SHIPMENT);
+    }
+
+    function it_can_equals_another_refund_type(): void
+    {
+        $this->beConstructedThrough('shipment');
+        $this->equals(RefundType::shipment())->shouldReturn(true);
+        $this->equals(RefundType::orderItemUnit())->shouldReturn(false);
+    }
+
+    function it_throws_exception_if_passed_refund_type_cannot_be_resolved(): void
+    {
+        $this
+            ->shouldThrow(RefundTypeNotResolved::withType('test'))
+            ->during('__construct', ['test'])
+        ;
+    }
+}

--- a/spec/StateResolver/OrderFullyRefundedStateResolverSpec.php
+++ b/spec/StateResolver/OrderFullyRefundedStateResolverSpec.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\StateResolver;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalCheckerInterface;
+use Sylius\RefundPlugin\StateResolver\OrderTransitions;
+
+final class OrderFullyRefundedStateResolverSpec extends ObjectBehavior
+{
+    function let(
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager,
+        OrderFullyRefundedTotalCheckerInterface $orderFullyRefundedTotalChecker,
+        OrderRepositoryInterface $orderRepository
+    ): void {
+        $this->beConstructedWith(
+            $stateMachineFactory,
+            $orderManager,
+            $orderFullyRefundedTotalChecker,
+            $orderRepository
+        );
+    }
+
+    function it_applies_refund_transition_on_order(
+        OrderRepositoryInterface $orderRepository,
+        OrderFullyRefundedTotalCheckerInterface $orderFullyRefundedTotalChecker,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager,
+        OrderInterface $order,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneByNumber('000222')->willReturn($order);
+        $orderFullyRefundedTotalChecker->isOrderFullyRefunded($order)->willReturn(true);
+        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+
+        $stateMachineFactory->get($order, OrderTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->apply(OrderTransitions::TRANSITION_REFUND)->shouldBeCalled();
+
+        $orderManager->flush()->shouldBeCalled();
+
+        $this->resolve('000222');
+    }
+
+    function it_does_nothing_if_order_state_is_fully_refunded(
+        OrderRepositoryInterface $orderRepository,
+        OrderFullyRefundedTotalCheckerInterface $orderFullyRefundedTotalChecker,
+        FactoryInterface $stateMachineFactory,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('000222')->willReturn($order);
+        $orderFullyRefundedTotalChecker->isOrderFullyRefunded($order)->willReturn(true);
+        $order->getState()->willReturn(OrderTransitions::STATE_FULLY_REFUNDED);
+
+        $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
+
+        $this->resolve('000222');
+    }
+
+    function it_does_nothing_if_order_is_not_fully_refunded(
+        OrderRepositoryInterface $orderRepository,
+        OrderFullyRefundedTotalCheckerInterface $orderFullyRefundedTotalChecker,
+        FactoryInterface $stateMachineFactory,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('000222')->willReturn($order);
+        $orderFullyRefundedTotalChecker->isOrderFullyRefunded($order)->willReturn(false);
+
+        $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
+
+        $this->resolve('000222');
+    }
+
+    function it_throws_exception_if_there_is_no_order_with_given_number(OrderRepositoryInterface $orderRepository): void
+    {
+        $orderRepository->findOneByNumber('000222')->willReturn(null);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('resolve', ['000222'])
+        ;
+    }
+}

--- a/spec/Validator/RefundAmountValidatorSpec.php
+++ b/spec/Validator/RefundAmountValidatorSpec.php
@@ -23,6 +23,20 @@ final class RefundAmountValidatorSpec extends ObjectBehavior
         $this->shouldImplement(RefundAmountValidatorInterface::class);
     }
 
+    function it_throws_exception_if_unit_refund_total_is_bigger_than_remaining_unit_refunded_total(
+        RemainingTotalProviderInterface $remainingTotalProvider
+    ): void {
+        $correctOrderItemUnitRefund = new OrderItemUnitRefund(2, 10);
+        $refundType = RefundType::orderItemUnit();
+
+        $remainingTotalProvider->getTotalLeftToRefund(2, $refundType)->willReturn(5);
+
+        $this
+            ->shouldThrow(InvalidRefundAmountException::class)
+            ->during('validateUnits', [[$correctOrderItemUnitRefund], $refundType])
+        ;
+    }
+
     function it_throws_exception_if_total_of_at_least_one_unit_is_below_zero(): void
     {
         $incorrectOrderItemUnitRefund = new OrderItemUnitRefund(1, -10);

--- a/src/Listener/CreditMemoGeneratedEventListener.php
+++ b/src/Listener/CreditMemoGeneratedEventListener.php
@@ -12,6 +12,7 @@ use Sylius\RefundPlugin\Event\CreditMemoGenerated;
 use Sylius\RefundPlugin\Exception\CreditMemoNotFound;
 use Sylius\RefundPlugin\Exception\OrderNotFound;
 use Sylius\RefundPlugin\Sender\CreditMemoEmailSenderInterface;
+use Webmozart\Assert\Assert;
 
 final class CreditMemoGeneratedEventListener
 {
@@ -48,9 +49,7 @@ final class CreditMemoGeneratedEventListener
             throw OrderNotFound::withNumber($event->orderNumber());
         }
 
-        if ($order->getCustomer() === null) {
-            throw new \InvalidArgumentException('Credit memo order has no customer');
-        }
+        Assert::notNull($order->getCustomer(), 'Credit memo order has no customer');
 
         $this->creditMemoEmailSender->send($creditMemo, $order->getCustomer()->getEmail());
     }

--- a/src/StateResolver/OrderFullyRefundedStateResolver.php
+++ b/src/StateResolver/OrderFullyRefundedStateResolver.php
@@ -43,8 +43,10 @@ final class OrderFullyRefundedStateResolver implements OrderFullyRefundedStateRe
         $order = $this->orderRepository->findOneByNumber($orderNumber);
         Assert::notNull($order);
 
-        if (!$this->orderFullyRefundedTotalChecker->isOrderFullyRefunded($order) ||
-            OrderTransitions::STATE_FULLY_REFUNDED === $order->getState()) {
+        if (
+            !$this->orderFullyRefundedTotalChecker->isOrderFullyRefunded($order) ||
+            OrderTransitions::STATE_FULLY_REFUNDED === $order->getState()
+        ) {
             return;
         }
 


### PR DESCRIPTION
Although I know that phpspec code coverage is a little bit controversial (in BDD you don't test, you describe, if you had not done it before, there is no point to go back), I think on Sylius plugins we can try to introduce some even more strict approach to testing than on Sylius itself. The variable there is a project size, we have pretty quick Travis build on plugins, much quicker than on Sylius, so if we slow down it a little bit with some code coverage check (it does not fail the build <yet?>, but displays a message) it won't be a big harm and it can give us potential benefits.

So, test coverage before this change:
<img width="1159" alt="zrzut ekranu 2019-02-18 o 14 27 07" src="https://user-images.githubusercontent.com/6212718/52961461-46115800-339b-11e9-9172-95712781fd24.png">

After:
<img width="1173" alt="zrzut ekranu 2019-02-18 o 16 23 30" src="https://user-images.githubusercontent.com/6212718/52961471-4ad60c00-339b-11e9-9627-44226646d367.png">

We missed few of them :)

I've also extracted a PHPSpec (with code coverage) build for a separated build. It makes sense IMO and can be used in the future for mutation tests (that's my dream 😍). 

I really believe that with such changes this plugin (together with other Sylius plugins) can became a real state-of-the-art technical wonder 🗽