### PR TITLE
Order payment state usage + "Partially refunded" state

### DIFF
--- a/features/having_order_fully_refunded.feature
+++ b/features/having_order_fully_refunded.feature
@@ -18,5 +18,5 @@ Feature: Having order fully refunded
 
     @ui
     Scenario: Having order fully refunded when both items and shipping are refunded
-        When I view the summary of the order "#00000022"
-        Then its state should be "Fully refunded"
+        When I browse orders
+        Then the order "#00000022" should have order payment state "Refunded"

--- a/features/having_order_partially_refunded.feature
+++ b/features/having_order_partially_refunded.feature
@@ -1,0 +1,22 @@
+@refunds
+Feature: Having order partially refunded
+    In order to note that part of the order total is refunded
+    As an Administrator
+    I want to have order partially refunded
+
+    Background:
+        Given the store operates on a single green channel in "United States"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
+        And the store has "Galaxy Post" shipping method with "$10.00" fee
+        And the store allows paying with "Space money"
+        And there is a customer "rick.sanchez@wubba-lubba-dub-dub.com" that placed an order "#00000022"
+        And the customer bought 3 "Mr. Meeseeks T-Shirt" products
+        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And I am logged in as an administrator
+        And the order "#00000022" is already paid
+
+    @ui
+    Scenario: Having order partially refunded when some items are refunded
+        Given 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded with "Space money" payment
+        When I browse orders
+        Then the order "#00000022" should have order payment state "Partially refunded"

--- a/features/having_order_partially_refunded.feature
+++ b/features/having_order_partially_refunded.feature
@@ -2,7 +2,7 @@
 Feature: Having order partially refunded
     In order to note that part of the order total is refunded
     As an Administrator
-    I want to have order partially refunded
+    I want to be aware of the order payment state being partially refunded
 
     Background:
         Given the store operates on a single green channel in "United States"
@@ -17,12 +17,10 @@ Feature: Having order partially refunded
 
     @ui
     Scenario: Having order partially refunded when some items are refunded
-        Given 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded with "Space money" payment
-        When I browse orders
-        Then the order "#00000022" should have order payment state "Partially refunded"
+        When 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded with "Space money" payment
+        Then this order's payment state should be "Partially refunded"
 
     @ui
     Scenario: Having order partially refunded when its shipping is refunded
-        Given shipment from order "#00000022" has already "$1.00" refunded with "Space money" payment
-        When I browse orders
-        Then the order "#00000022" should have order payment state "Partially refunded"
+        When shipment from order "#00000022" has already "$1.00" refunded with "Space money" payment
+        Then this order's payment state should be "Partially refunded"

--- a/features/having_order_partially_refunded.feature
+++ b/features/having_order_partially_refunded.feature
@@ -20,3 +20,9 @@ Feature: Having order partially refunded
         Given 1st "Mr. Meeseeks T-Shirt" product from order "#00000022" has already been refunded with "Space money" payment
         When I browse orders
         Then the order "#00000022" should have order payment state "Partially refunded"
+
+    @ui
+    Scenario: Having order partially refunded when its shipping is refunded
+        Given shipment from order "#00000022" has already "$1.00" refunded with "Space money" payment
+        When I browse orders
+        Then the order "#00000022" should have order payment state "Partially refunded"

--- a/spec/Checker/OrderRefundingAvailabilityCheckerSpec.php
+++ b/spec/Checker/OrderRefundingAvailabilityCheckerSpec.php
@@ -32,7 +32,27 @@ final class OrderRefundingAvailabilityCheckerSpec extends ObjectBehavior
         $this('00000007')->shouldReturn(true);
     }
 
-    function it_returns_false_if_order_is_unpaid(
+    function it_returns_true_if_order_is_refunded(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('00000007')->willReturn($order);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_REFUNDED);
+
+        $this('00000007')->shouldReturn(true);
+    }
+
+    function it_returns_true_if_order_is_partialy_refunded(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('00000007')->willReturn($order);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PARTIALLY_REFUNDED);
+
+        $this('00000007')->shouldReturn(true);
+    }
+
+    function it_returns_false_if_order_is_in_other_state(
         OrderRepositoryInterface $orderRepository,
         OrderInterface $order
     ): void {

--- a/spec/Checker/OrderRefundsListAvailabilityCheckerSpec.php
+++ b/spec/Checker/OrderRefundsListAvailabilityCheckerSpec.php
@@ -10,7 +10,7 @@ use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 
-final class OrderRefundingAvailabilityCheckerSpec extends ObjectBehavior
+final class OrderRefundsListAvailabilityCheckerSpec extends ObjectBehavior
 {
     function let(OrderRepositoryInterface $orderRepository): void
     {
@@ -28,6 +28,16 @@ final class OrderRefundingAvailabilityCheckerSpec extends ObjectBehavior
     ): void {
         $orderRepository->findOneByNumber('00000007')->willReturn($order);
         $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
+
+        $this('00000007')->shouldReturn(true);
+    }
+
+    function it_returns_true_if_order_is_refunded(
+        OrderRepositoryInterface $orderRepository,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('00000007')->willReturn($order);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_REFUNDED);
 
         $this('00000007')->shouldReturn(true);
     }

--- a/spec/Listener/ShipmentRefundedEventListenerSpec.php
+++ b/spec/Listener/ShipmentRefundedEventListenerSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Listener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\RefundPlugin\Event\ShipmentRefunded;
+use Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolverInterface;
+
+final class ShipmentRefundedEventListenerSpec extends ObjectBehavior
+{
+    function let(OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver): void
+    {
+        $this->beConstructedWith($orderPartiallyRefundedStateResolver);
+    }
+
+    function it_resolves_order_partially_refunded_state(
+        OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver
+    ): void {
+        $orderPartiallyRefundedStateResolver->resolve('000777')->shouldBeCalled();
+
+        $this->__invoke(new ShipmentRefunded('000777', 10, 1000));
+    }
+}

--- a/spec/Listener/UnitRefundedEventListenerSpec.php
+++ b/spec/Listener/UnitRefundedEventListenerSpec.php
@@ -4,68 +4,22 @@ declare(strict_types=1);
 
 namespace spec\Sylius\RefundPlugin\Listener;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use SM\Factory\FactoryInterface;
-use SM\StateMachine\StateMachineInterface;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderPaymentStates;
-use Sylius\Component\Core\OrderPaymentTransitions;
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Event\UnitRefunded;
-use Sylius\RefundPlugin\Exception\OrderNotFound;
+use Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolverInterface;
 
 final class UnitRefundedEventListenerSpec extends ObjectBehavior
 {
-    function let(
-        OrderRepositoryInterface $orderRepository,
-        FactoryInterface $stateMachineFactory,
-        ObjectManager $orderManager
-    ): void {
-        $this->beConstructedWith($orderRepository, $stateMachineFactory, $orderManager);
-    }
-
-    function it_marks_order_as_partially_refunded(
-        OrderRepositoryInterface $orderRepository,
-        FactoryInterface $stateMachineFactory,
-        ObjectManager $orderManager,
-        OrderInterface $order,
-        StateMachineInterface $stateMachine
-    ): void {
-        $orderRepository->findOneByNumber('000777')->willReturn($order);
-
-        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
-
-        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
-        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND)->shouldBeCalled();
-
-        $orderManager->flush()->shouldBeCalled();
-
-        $this->__invoke(new UnitRefunded('000777', 10, 1000));
-    }
-
-    function it_does_nothing_if_order_is_already_marked_as_partially_refunded(
-        OrderRepositoryInterface $orderRepository,
-        FactoryInterface $stateMachineFactory,
-        OrderInterface $order
-    ): void {
-        $orderRepository->findOneByNumber('000777')->willReturn($order);
-
-        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PARTIALLY_REFUNDED);
-
-        $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
-
-        $this->__invoke(new UnitRefunded('000777', 10, 1000));
-    }
-
-    function it_throws_exception_if_there_is_no_order_with_given_number(OrderRepositoryInterface $orderRepository): void
+    function let(OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver): void
     {
-        $orderRepository->findOneByNumber('000777')->willReturn(null);
+        $this->beConstructedWith($orderPartiallyRefundedStateResolver);
+    }
 
-        $this
-            ->shouldThrow(OrderNotFound::withNumber('000777'))
-            ->during('__invoke', [new UnitRefunded('000777', 10, 1000)])
-        ;
+    function it_resolves_order_partially_refunded_state(
+        OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver
+    ): void {
+        $orderPartiallyRefundedStateResolver->resolve('000777')->shouldBeCalled();
+
+        $this->__invoke(new UnitRefunded('000777', 10, 1000));
     }
 }

--- a/spec/Listener/UnitRefundedEventListenerSpec.php
+++ b/spec/Listener/UnitRefundedEventListenerSpec.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\Listener;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+
+final class UnitRefundedEventListenerSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager
+    ): void {
+        $this->beConstructedWith($orderRepository, $stateMachineFactory, $orderManager);
+    }
+
+    function it_marks_order_as_partially_refunded(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager,
+        OrderInterface $order,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneByNumber('000777')->willReturn($order);
+
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
+
+        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND)->shouldBeCalled();
+
+        $orderManager->flush()->shouldBeCalled();
+
+        $this->__invoke(new UnitRefunded('000777', 10, 1000));
+    }
+
+    function it_does_nothing_if_order_is_already_marked_as_partially_refunded(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('000777')->willReturn($order);
+
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PARTIALLY_REFUNDED);
+
+        $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
+
+        $this->__invoke(new UnitRefunded('000777', 10, 1000));
+    }
+
+    function it_throws_exception_if_there_is_no_order_with_given_number(OrderRepositoryInterface $orderRepository): void
+    {
+        $orderRepository->findOneByNumber('000777')->willReturn(null);
+
+        $this
+            ->shouldThrow(OrderNotFound::withNumber('000777'))
+            ->during('__invoke', [new UnitRefunded('000777', 10, 1000)])
+        ;
+    }
+}

--- a/spec/StateResolver/OrderFullyRefundedStateResolverSpec.php
+++ b/spec/StateResolver/OrderFullyRefundedStateResolverSpec.php
@@ -10,9 +10,10 @@ use Prophecy\Argument;
 use SM\Factory\FactoryInterface;
 use SM\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\OrderPaymentTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalCheckerInterface;
-use Sylius\RefundPlugin\StateResolver\OrderTransitions;
 
 final class OrderFullyRefundedStateResolverSpec extends ObjectBehavior
 {
@@ -42,8 +43,8 @@ final class OrderFullyRefundedStateResolverSpec extends ObjectBehavior
         $orderFullyRefundedTotalChecker->isOrderFullyRefunded($order)->willReturn(true);
         $order->getState()->willReturn(OrderInterface::STATE_NEW);
 
-        $stateMachineFactory->get($order, OrderTransitions::GRAPH)->willReturn($stateMachine);
-        $stateMachine->apply(OrderTransitions::TRANSITION_REFUND)->shouldBeCalled();
+        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_REFUND)->shouldBeCalled();
 
         $orderManager->flush()->shouldBeCalled();
 
@@ -58,7 +59,7 @@ final class OrderFullyRefundedStateResolverSpec extends ObjectBehavior
     ): void {
         $orderRepository->findOneByNumber('000222')->willReturn($order);
         $orderFullyRefundedTotalChecker->isOrderFullyRefunded($order)->willReturn(true);
-        $order->getState()->willReturn(OrderTransitions::STATE_FULLY_REFUNDED);
+        $order->getState()->willReturn(OrderPaymentStates::STATE_REFUNDED);
 
         $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
 

--- a/spec/StateResolver/OrderPartiallyRefundedStateResolverSpec.php
+++ b/spec/StateResolver/OrderPartiallyRefundedStateResolverSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\StateResolver;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+
+final class OrderPartiallyRefundedStateResolverSpec extends ObjectBehavior
+{
+    function let(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager
+    ): void {
+        $this->beConstructedWith($orderRepository, $stateMachineFactory, $orderManager);
+    }
+
+    function it_marks_order_as_partially_refunded(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager,
+        OrderInterface $order,
+        StateMachineInterface $stateMachine
+    ): void {
+        $orderRepository->findOneByNumber('000777')->willReturn($order);
+
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
+
+        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND)->shouldBeCalled();
+
+        $orderManager->flush()->shouldBeCalled();
+
+        $this->resolve('000777');
+    }
+
+    function it_does_nothing_if_order_is_already_marked_as_partially_refunded(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        OrderInterface $order
+    ): void {
+        $orderRepository->findOneByNumber('000777')->willReturn($order);
+
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PARTIALLY_REFUNDED);
+
+        $stateMachineFactory->get(Argument::any())->shouldNotBeCalled();
+
+        $this->resolve('000777');
+    }
+
+    function it_throws_exception_if_there_is_no_order_with_given_number(OrderRepositoryInterface $orderRepository): void
+    {
+        $orderRepository->findOneByNumber('000777')->willReturn(null);
+
+        $this
+            ->shouldThrow(OrderNotFound::withNumber('000777'))
+            ->during('resolve', ['000777'])
+        ;
+    }
+}

--- a/src/Action/Admin/OrderRefundsListAction.php
+++ b/src/Action/Admin/OrderRefundsListAction.php
@@ -21,7 +21,7 @@ final class OrderRefundsListAction
     private $orderRepository;
 
     /** @var OrderRefundingAvailabilityCheckerInterface */
-    private $orderRefundingAvailabilityChecker;
+    private $orderRefundsListAvailabilityChecker;
 
     /** @var RefundPaymentMethodsProviderInterface */
     private $refundPaymentMethodsProvider;
@@ -37,14 +37,14 @@ final class OrderRefundsListAction
 
     public function __construct(
         OrderRepositoryInterface $orderRepository,
-        OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker,
+        OrderRefundingAvailabilityCheckerInterface $orderRefundsListAvailabilityChecker,
         RefundPaymentMethodsProviderInterface $refundPaymentMethodsProvider,
         Environment $twig,
         Session $session,
         UrlGeneratorInterface $router
     ) {
         $this->orderRepository = $orderRepository;
-        $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
+        $this->orderRefundsListAvailabilityChecker = $orderRefundsListAvailabilityChecker;
         $this->refundPaymentMethodsProvider = $refundPaymentMethodsProvider;
         $this->twig = $twig;
         $this->session = $session;
@@ -56,7 +56,7 @@ final class OrderRefundsListAction
         /** @var OrderInterface $order */
         $order = $this->orderRepository->findOneByNumber($request->attributes->get('orderNumber'));
 
-        if (!$this->orderRefundingAvailabilityChecker->__invoke($request->attributes->get('orderNumber'))) {
+        if (!$this->orderRefundsListAvailabilityChecker->__invoke($request->attributes->get('orderNumber'))) {
             return $this->redirectToReferer($order);
         }
 

--- a/src/Checker/OrderRefundingAvailabilityChecker.php
+++ b/src/Checker/OrderRefundingAvailabilityChecker.php
@@ -25,6 +25,9 @@ final class OrderRefundingAvailabilityChecker implements OrderRefundingAvailabil
         $order = $this->orderRepository->findOneByNumber($orderNumber);
         Assert::notNull($order);
 
-        return $order->getPaymentState() === OrderPaymentStates::STATE_PAID;
+        return in_array(
+            $order->getPaymentState(),
+            [OrderPaymentStates::STATE_PAID, OrderPaymentStates::STATE_REFUNDED, OrderPaymentStates::STATE_PARTIALLY_REFUNDED]
+        );
     }
 }

--- a/src/Checker/OrderRefundsListAvailabilityChecker.php
+++ b/src/Checker/OrderRefundsListAvailabilityChecker.php
@@ -9,7 +9,7 @@ use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Webmozart\Assert\Assert;
 
-final class OrderRefundingAvailabilityChecker implements OrderRefundingAvailabilityCheckerInterface
+final class OrderRefundsListAvailabilityChecker implements OrderRefundingAvailabilityCheckerInterface
 {
     /** @var OrderRepositoryInterface */
     private $orderRepository;
@@ -27,7 +27,7 @@ final class OrderRefundingAvailabilityChecker implements OrderRefundingAvailabil
 
         return in_array(
             $order->getPaymentState(),
-            [OrderPaymentStates::STATE_PAID, OrderPaymentStates::STATE_PARTIALLY_REFUNDED]
+            [OrderPaymentStates::STATE_PAID, OrderPaymentStates::STATE_PARTIALLY_REFUNDED, OrderPaymentStates::STATE_REFUNDED]
         );
     }
 }

--- a/src/Listener/ShipmentRefundedEventListener.php
+++ b/src/Listener/ShipmentRefundedEventListener.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Listener;
+
+use Sylius\RefundPlugin\Event\ShipmentRefunded;
+use Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolverInterface;
+
+final class ShipmentRefundedEventListener
+{
+    /** @var OrderPartiallyRefundedStateResolverInterface */
+    private $orderPartiallyRefundedStateResolver;
+
+    public function __construct(OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver)
+    {
+        $this->orderPartiallyRefundedStateResolver = $orderPartiallyRefundedStateResolver;
+    }
+
+    public function __invoke(ShipmentRefunded $shipmentRefunded): void
+    {
+        $this->orderPartiallyRefundedStateResolver->resolve($shipmentRefunded->orderNumber());
+    }
+}

--- a/src/Listener/UnitRefundedEventListener.php
+++ b/src/Listener/UnitRefundedEventListener.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Listener;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Event\UnitRefunded;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+
+final class UnitRefundedEventListener
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var FactoryInterface */
+    private $stateMachineFactory;
+
+    /** @var ObjectManager */
+    private $orderManager;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->orderManager = $orderManager;
+    }
+
+    public function __invoke(UnitRefunded $unitRefunded): void
+    {
+        /** @var OrderInterface|null $order */
+        $order = $this->orderRepository->findOneByNumber($unitRefunded->orderNumber());
+        if ($order === null) {
+            throw OrderNotFound::withNumber($unitRefunded->orderNumber());
+        }
+
+        if ($order->getPaymentState() === OrderPaymentStates::STATE_PARTIALLY_REFUNDED) {
+            return;
+        }
+
+        $stateMachine = $this->stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND);
+
+        $this->orderManager->flush();
+    }
+}

--- a/src/Listener/UnitRefundedEventListener.php
+++ b/src/Listener/UnitRefundedEventListener.php
@@ -4,51 +4,21 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Listener;
 
-use Doctrine\Common\Persistence\ObjectManager;
-use SM\Factory\FactoryInterface;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderPaymentStates;
-use Sylius\Component\Core\OrderPaymentTransitions;
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Event\UnitRefunded;
-use Sylius\RefundPlugin\Exception\OrderNotFound;
+use Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolverInterface;
 
 final class UnitRefundedEventListener
 {
-    /** @var OrderRepositoryInterface */
-    private $orderRepository;
+    /** @var OrderPartiallyRefundedStateResolverInterface */
+    private $orderPartiallyRefundedStateResolver;
 
-    /** @var FactoryInterface */
-    private $stateMachineFactory;
-
-    /** @var ObjectManager */
-    private $orderManager;
-
-    public function __construct(
-        OrderRepositoryInterface $orderRepository,
-        FactoryInterface $stateMachineFactory,
-        ObjectManager $orderManager
-    ) {
-        $this->orderRepository = $orderRepository;
-        $this->stateMachineFactory = $stateMachineFactory;
-        $this->orderManager = $orderManager;
+    public function __construct(OrderPartiallyRefundedStateResolverInterface $orderPartiallyRefundedStateResolver)
+    {
+        $this->orderPartiallyRefundedStateResolver = $orderPartiallyRefundedStateResolver;
     }
 
     public function __invoke(UnitRefunded $unitRefunded): void
     {
-        /** @var OrderInterface|null $order */
-        $order = $this->orderRepository->findOneByNumber($unitRefunded->orderNumber());
-        if ($order === null) {
-            throw OrderNotFound::withNumber($unitRefunded->orderNumber());
-        }
-
-        if ($order->getPaymentState() === OrderPaymentStates::STATE_PARTIALLY_REFUNDED) {
-            return;
-        }
-
-        $stateMachine = $this->stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH);
-        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND);
-
-        $this->orderManager->flush();
+        $this->orderPartiallyRefundedStateResolver->resolve($unitRefunded->orderNumber());
     }
 }

--- a/src/Menu/OrderShowMenuListener.php
+++ b/src/Menu/OrderShowMenuListener.php
@@ -5,16 +5,24 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Menu;
 
 use Sylius\Bundle\AdminBundle\Event\OrderShowMenuBuilderEvent;
-use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 
 final class OrderShowMenuListener
 {
+    /** @var OrderRefundingAvailabilityCheckerInterface */
+    private $orderRefundingAvailabilityChecker;
+
+    public function __construct(OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker)
+    {
+        $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
+    }
+
     public function addRefundsButton(OrderShowMenuBuilderEvent $event): void
     {
         $menu = $event->getMenu();
         $order = $event->getOrder();
 
-        if ($order->getPaymentState() === OrderPaymentStates::STATE_PAID) {
+        if ($this->orderRefundingAvailabilityChecker->__invoke($order->getNumber())) {
             $menu
                 ->addChild('refunds', [
                     'route' => 'sylius_refund_order_refunds_list',

--- a/src/Menu/OrderShowMenuListener.php
+++ b/src/Menu/OrderShowMenuListener.php
@@ -10,11 +10,11 @@ use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 final class OrderShowMenuListener
 {
     /** @var OrderRefundingAvailabilityCheckerInterface */
-    private $orderRefundingAvailabilityChecker;
+    private $orderRefundsListAvailabilityChecker;
 
-    public function __construct(OrderRefundingAvailabilityCheckerInterface $orderRefundingAvailabilityChecker)
+    public function __construct(OrderRefundingAvailabilityCheckerInterface $orderRefundsListAvailabilityChecker)
     {
-        $this->orderRefundingAvailabilityChecker = $orderRefundingAvailabilityChecker;
+        $this->orderRefundsListAvailabilityChecker = $orderRefundsListAvailabilityChecker;
     }
 
     public function addRefundsButton(OrderShowMenuBuilderEvent $event): void
@@ -22,7 +22,7 @@ final class OrderShowMenuListener
         $menu = $event->getMenu();
         $order = $event->getOrder();
 
-        if ($this->orderRefundingAvailabilityChecker->__invoke($order->getNumber())) {
+        if ($this->orderRefundsListAvailabilityChecker->__invoke($order->getNumber())) {
             $menu
                 ->addChild('refunds', [
                     'route' => 'sylius_refund_order_refunds_list',

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -32,6 +32,9 @@
         <service id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker">
             <argument type="service" id="sylius.repository.order" />
         </service>
+        <service id="Sylius\RefundPlugin\Checker\OrderRefundsListAvailabilityChecker">
+            <argument type="service" id="sylius.repository.order" />
+        </service>
 
         <service id="Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityChecker">
             <argument type="service" id="Sylius\RefundPlugin\Provider\RemainingTotalProvider" />
@@ -45,7 +48,7 @@
         </service>
 
         <service id="Sylius\RefundPlugin\Menu\OrderShowMenuListener">
-            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
+            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundsListAvailabilityChecker" />
             <tag name="kernel.event_listener" event="sylius.menu.admin.order.show" method="addRefundsButton" />
         </service>
         <service id="Sylius\RefundPlugin\Menu\AdminMainMenuListener">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -45,6 +45,7 @@
         </service>
 
         <service id="Sylius\RefundPlugin\Menu\OrderShowMenuListener">
+            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
             <tag name="kernel.event_listener" event="sylius.menu.admin.order.show" method="addRefundsButton" />
         </service>
         <service id="Sylius\RefundPlugin\Menu\AdminMainMenuListener">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -59,6 +59,12 @@
             <argument type="service" id="sylius.repository.order" />
         </service>
 
+        <service id="Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolver">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.manager.order" />
+        </service>
+
         <service id="Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalChecker">
             <argument type="service" id="Sylius\RefundPlugin\Provider\OrderRefundedTotalProvider" />
         </service>

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -17,7 +17,7 @@
 
         <service id="Sylius\RefundPlugin\Action\Admin\OrderRefundsListAction">
             <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityChecker" />
+            <argument type="service" id="Sylius\RefundPlugin\Checker\OrderRefundsListAvailabilityChecker" />
             <argument type="service" id="Sylius\RefundPlugin\Provider\RefundPaymentMethodsProviderInterface" />
             <argument type="service" id="twig" />
             <argument type="service" id="session" />

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -11,6 +11,13 @@
             <tag name="messenger.message_handler" />
         </service>
 
+        <service id="Sylius\RefundPlugin\Listener\UnitRefundedEventListener">
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.manager.order" />
+            <tag name="messenger.message_handler" />
+        </service>
+
         <service id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager">
             <argument type="service" id="sylius_refund_plugin.command_bus" />
             <tag name="messenger.message_handler" />

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -16,6 +16,11 @@
             <tag name="messenger.message_handler" />
         </service>
 
+        <service id="Sylius\RefundPlugin\Listener\ShipmentRefundedEventListener">
+            <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolver" />
+            <tag name="messenger.message_handler" />
+        </service>
+
         <service id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager">
             <argument type="service" id="sylius_refund_plugin.command_bus" />
             <tag name="messenger.message_handler" />

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -12,9 +12,7 @@
         </service>
 
         <service id="Sylius\RefundPlugin\Listener\UnitRefundedEventListener">
-            <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="sm.factory" />
-            <argument type="service" id="sylius.manager.order" />
+            <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolver" />
             <tag name="messenger.message_handler" />
         </service>
 

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -21,5 +21,5 @@ sylius_refund:
 
 sylius:
     ui:
-        fully_refunded: 'Fully refunded'
         original_payment_method: "Original Payment Method"
+        partially_refunded: 'Partially refunded'

--- a/src/Resources/views/SyliusAdminBundle/Order/Label/State/fully_refunded.html.twig
+++ b/src/Resources/views/SyliusAdminBundle/Order/Label/State/fully_refunded.html.twig
@@ -1,4 +1,0 @@
-<span class="ui purple label">
-    <i class="check icon"></i>
-    {{ value|trans }}
-</span>

--- a/src/StateResolver/OrderFullyRefundedStateResolver.php
+++ b/src/StateResolver/OrderFullyRefundedStateResolver.php
@@ -7,6 +7,7 @@ namespace Sylius\RefundPlugin\StateResolver;
 use Doctrine\Common\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\OrderPaymentTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalCheckerInterface;
@@ -46,7 +47,7 @@ final class OrderFullyRefundedStateResolver implements OrderFullyRefundedStateRe
 
         if (
             !$this->orderFullyRefundedTotalChecker->isOrderFullyRefunded($order) ||
-            OrderTransitions::STATE_FULLY_REFUNDED === $order->getState()
+            OrderPaymentStates::STATE_REFUNDED === $order->getState()
         ) {
             return;
         }

--- a/src/StateResolver/OrderFullyRefundedStateResolver.php
+++ b/src/StateResolver/OrderFullyRefundedStateResolver.php
@@ -7,6 +7,7 @@ namespace Sylius\RefundPlugin\StateResolver;
 use Doctrine\Common\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Checker\OrderFullyRefundedTotalCheckerInterface;
 use Webmozart\Assert\Assert;
@@ -50,9 +51,9 @@ final class OrderFullyRefundedStateResolver implements OrderFullyRefundedStateRe
             return;
         }
 
-        $stateMachine = $this->stateMachineFactory->get($order, OrderTransitions::GRAPH);
+        $stateMachine = $this->stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH);
 
-        $stateMachine->apply(OrderTransitions::TRANSITION_REFUND);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_REFUND);
 
         $this->orderManager->flush();
     }

--- a/src/StateResolver/OrderPartiallyRefundedStateResolver.php
+++ b/src/StateResolver/OrderPartiallyRefundedStateResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\StateResolver;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\RefundPlugin\Exception\OrderNotFound;
+
+final class OrderPartiallyRefundedStateResolver implements OrderPartiallyRefundedStateResolverInterface
+{
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var FactoryInterface */
+    private $stateMachineFactory;
+
+    /** @var ObjectManager */
+    private $orderManager;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        FactoryInterface $stateMachineFactory,
+        ObjectManager $orderManager
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->orderManager = $orderManager;
+    }
+
+    public function resolve(string $orderNumber): void
+    {
+        /** @var OrderInterface|null $order */
+        $order = $this->orderRepository->findOneByNumber($orderNumber);
+        if ($order === null) {
+            throw OrderNotFound::withNumber($orderNumber);
+        }
+
+        if ($order->getPaymentState() === OrderPaymentStates::STATE_PARTIALLY_REFUNDED) {
+            return;
+        }
+
+        $stateMachine = $this->stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND);
+
+        $this->orderManager->flush();
+    }
+}

--- a/src/StateResolver/OrderPartiallyRefundedStateResolverInterface.php
+++ b/src/StateResolver/OrderPartiallyRefundedStateResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\StateResolver;
+
+interface OrderPartiallyRefundedStateResolverInterface
+{
+    public function resolve(string $orderNumber): void;
+}

--- a/tests/Application/config/packages/test/knp_snappy.yaml
+++ b/tests/Application/config/packages/test/knp_snappy.yaml
@@ -1,3 +1,3 @@
-knp_snappy:
-    pdf:
-        binary: "%kernel.project_dir%/etc/wkhtmltopdf"
+#knp_snappy:
+#    pdf:
+#        binary: "%kernel.project_dir%/etc/wkhtmltopdf"

--- a/tests/Application/config/packages/test/knp_snappy.yaml
+++ b/tests/Application/config/packages/test/knp_snappy.yaml
@@ -1,3 +1,3 @@
-#knp_snappy:
-#    pdf:
-#        binary: "%kernel.project_dir%/etc/wkhtmltopdf"
+knp_snappy:
+    pdf:
+        binary: "%kernel.project_dir%/etc/wkhtmltopdf"

--- a/tests/Behat/Context/Setup/RefundingContext.php
+++ b/tests/Behat/Context/Setup/RefundingContext.php
@@ -105,6 +105,7 @@ final class RefundingContext implements Context
 
     /**
      * @Given /^all units and shipment from the order "#([^"]+)" are refunded with ("[^"]+" payment)$/
+     * @Given /^all units and shipment from the order "#([^"]+)" have been refunded with ("[^"]+" payment)$/
      */
     public function allUnitsAndShipmentFromOrderAreRefunded(
         string $orderNumber,

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -6,6 +6,7 @@ namespace Tests\Sylius\RefundPlugin\Behat\Context\Ui;
 
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
+use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -16,14 +17,19 @@ final class ManagingOrdersContext implements Context
     /** @var ShowPageInterface */
     private $showPage;
 
+    /** @var IndexPageInterface */
+    private $indexPage;
+
     /** @var NotificationCheckerInterface */
     private $notificationChecker;
 
     public function __construct(
         ShowPageInterface $showPage,
+        IndexPageInterface $indexPage,
         NotificationCheckerInterface $notificationChecker
     ) {
         $this->showPage = $showPage;
+        $this->indexPage = $indexPage;
         $this->notificationChecker = $notificationChecker;
     }
 
@@ -87,5 +93,17 @@ final class ManagingOrdersContext implements Context
     public function shouldNotBeAbleToCompleteTheFirstRefundPaymentAgain(): void
     {
         Assert::false($this->showPage->canCompleteRefundPayment(0));
+    }
+
+    /**
+     * @Then /^(this order)'s payment state should be "([^"]+)"$/
+     */
+    public function thisOrderSPaymentStateShouldBe(OrderInterface $order, string $orderPaymentState): void
+    {
+        $this->indexPage->open();
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'number' => $order->getNumber(),
+            'paymentState' => $orderPaymentState,
+        ]));
     }
 }

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -40,6 +40,7 @@
 
         <service id="Tests\Sylius\RefundPlugin\Behat\Context\Ui\ManagingOrdersContext">
             <argument type="service" id="sylius.behat.page.admin.order.show" />
+            <argument type="service" id="sylius.behat.page.admin.order.index" />
             <argument type="service" id="sylius.behat.notification_checker" />
         </service>
 


### PR DESCRIPTION
Fixes https://github.com/Sylius/RefundPlugin/issues/111

It was a mistake, to use the main order state machine to mark orders as refunded. Now "refunded" state is shown as an order payment state. Additionally, I've implemented marking order as "partially refunded" when *something* has been refunded.

<img width="284" alt="zrzut ekranu 2019-02-21 o 16 38 49" src="https://user-images.githubusercontent.com/6212718/53238089-b1f40900-3698-11e9-8489-7f6d1a6f3f13.png">
<img width="290" alt="zrzut ekranu 2019-02-22 o 11 38 27" src="https://user-images.githubusercontent.com/6212718/53238090-b1f40900-3698-11e9-8ccd-6d4ab3bbd1a6.png">
