### PR TITLE
[HotFix] Return proper type in Refund type

### DIFF
--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -21,7 +21,7 @@ class Refund implements RefundInterface
     /** @var int */
     private $refundedUnitId;
 
-    /** @var RefundType */
+    /** @var string */
     private $type;
 
     public function __construct(string $orderNumber, int $amount, int $refundedUnitId, RefundType $type)
@@ -29,7 +29,7 @@ class Refund implements RefundInterface
         $this->orderNumber = $orderNumber;
         $this->amount = $amount;
         $this->refundedUnitId = $refundedUnitId;
-        $this->type = $type;
+        $this->type = $type->__toString();
     }
 
     public function getId(): ?int
@@ -54,6 +54,6 @@ class Refund implements RefundInterface
 
     public function getType(): RefundType
     {
-        return $this->type;
+        return new RefundType($this->type);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Sylius/RefundPlugin/issues/108

It's a hotfix, but not changing a current functionality - `Refund::$type` was indeed set in a database as a `string`. In fact, we should consider what to do with this property, as it's used nowhere 😄 and that was a reason why this bug has not been detected by tests. We should either remove this property or use it somewhere to avoid having a dead code ☠️ 