### PR TITLE
Check events dispatching for real

### DIFF
--- a/spec/CommandHandler/GenerateCreditMemoHandlerSpec.php
+++ b/spec/CommandHandler/GenerateCreditMemoHandlerSpec.php
@@ -42,7 +42,7 @@ final class GenerateCreditMemoHandlerSpec extends ObjectBehavior
         $creditMemoManager->flush()->shouldBeCalled();
 
         $event = new CreditMemoGenerated('2018/01/000001', '000666');
-        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
         $this(new GenerateCreditMemo('000666', 7000, $orderItemUnitRefunds, $shipmentRefunds, 'Comment'));
     }

--- a/spec/CommandHandler/RefundUnitsHandlerSpec.php
+++ b/spec/CommandHandler/RefundUnitsHandlerSpec.php
@@ -56,7 +56,7 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
         $refundUnitsCommandValidator->validate(Argument::type(RefundUnits::class))->shouldBeCalled();
 
         $event = new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 7000, 'USD', 'Comment');
-        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
         $this(new RefundUnits('000222', $unitRefunds, $shipmentRefunds, 1, 'Comment'));
     }
@@ -81,7 +81,7 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
         $refundUnitsCommandValidator->validate(Argument::type(RefundUnits::class))->shouldBeCalled();
 
         $event = new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 1500, 'USD', 'Comment');
-        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
         $this(new RefundUnits('000222', $unitRefunds, $shipmentRefunds, 1, 'Comment'));
     }

--- a/spec/ProcessManager/CreditMemoProcessManagerSpec.php
+++ b/spec/ProcessManager/CreditMemoProcessManagerSpec.php
@@ -25,7 +25,7 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
         $shipmentRefunds = [new ShipmentRefund(1, 500), new ShipmentRefund(2, 1000)];
 
         $command = new GenerateCreditMemo('000222', 3000, $unitRefunds, $shipmentRefunds, 'Comment');
-        $commandBus->dispatch($command)->willReturn(new Envelope($command));
+        $commandBus->dispatch($command)->willReturn(new Envelope($command))->shouldBeCalled();
 
         $this(new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 3000, 'USD', 'Comment'));
     }

--- a/spec/ProcessManager/RefundPaymentProcessManagerSpec.php
+++ b/spec/ProcessManager/RefundPaymentProcessManagerSpec.php
@@ -62,7 +62,7 @@ final class RefundPaymentProcessManagerSpec extends ObjectBehavior
         $relatedPaymentIdProvider->getForRefundPayment($refundPayment)->willReturn(3);
 
         $event = new RefundPaymentGenerated(10, '000222', 1000, 'USD', 1, 3);
-        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
         $this(new UnitsRefunded('000222', [new OrderItemUnitRefund(1, 500), new OrderItemUnitRefund(2, 500)], [1], 1, 1000, 'USD', 'Comment'));
     }

--- a/spec/Refunder/OrderItemUnitsRefunderSpec.php
+++ b/spec/Refunder/OrderItemUnitsRefunderSpec.php
@@ -37,12 +37,12 @@ final class OrderItemUnitsRefunderSpec extends ObjectBehavior
         $refundCreator->__invoke('000222', 1, 1500, RefundType::orderItemUnit())->shouldBeCalled();
 
         $firstEvent = new UnitRefunded('000222', 1, 1500);
-        $eventBus->dispatch($firstEvent)->willReturn(new Envelope($firstEvent));
+        $eventBus->dispatch($firstEvent)->willReturn(new Envelope($firstEvent))->shouldBeCalled();
 
         $refundCreator->__invoke('000222', 3, 1000, RefundType::orderItemUnit())->shouldBeCalled();
 
         $secondEvent = new UnitRefunded('000222', 3, 1000);
-        $eventBus->dispatch($secondEvent)->willReturn(new Envelope($secondEvent));
+        $eventBus->dispatch($secondEvent)->willReturn(new Envelope($secondEvent))->shouldBeCalled();
 
         $this->refundFromOrder([$firstUnitRefund, $secondUnitRefund], '000222')->shouldReturn(2500);
     }

--- a/spec/Refunder/OrderShipmentsRefunderSpec.php
+++ b/spec/Refunder/OrderShipmentsRefunderSpec.php
@@ -34,7 +34,7 @@ final class OrderShipmentsRefunderSpec extends ObjectBehavior
         $refundCreator->__invoke('000222', 4, 2500, RefundType::shipment())->shouldBeCalled();
 
         $event = new ShipmentRefunded('000222', 4, 2500);
-        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
         $this->refundFromOrder($shipmentRefunds, '000222')->shouldReturn(2500);
     }


### PR DESCRIPTION
Without `shouldBeCalled()`, we could remove the `dispatch($event)` call and test were still passing 😢 