### PR TITLE
MappedSuperclass with embeddables

### DIFF
--- a/src/Doctrine/Mapping/Driver/DriverChain.php
+++ b/src/Doctrine/Mapping/Driver/DriverChain.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Doctrine\Mapping\Driver;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain as BaseMappingDriverChain;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+class DriverChain implements MappingDriver
+{
+    /** @var BaseMappingDriverChain */
+    private $baseMappingDriverChain;
+
+    /** @var EntityManager */
+    private $entityManager;
+
+    public function __construct(BaseMappingDriverChain $baseMappingDriverChain, EntityManager $entityManager)
+    {
+        $this->baseMappingDriverChain = $baseMappingDriverChain;
+        $this->entityManager = $entityManager;
+    }
+
+    public function loadMetadataForClass($className, ClassMetadata $metadata): void
+    {
+        $this->baseMappingDriverChain->loadMetadataForClass($className, $metadata);
+
+        if (
+            $this->entityManager->getEventManager()->hasListeners('preEmbeddableResolve') &&
+            !empty($metadata->embeddedClasses)
+        ) {
+            $eventArgs = new LoadClassMetadataEventArgs($metadata, $this->entityManager);
+            $this->entityManager->getEventManager()->dispatchEvent('preEmbeddableResolve', $eventArgs);
+        }
+    }
+
+    public function getAllClassNames()
+    {
+        return $this->baseMappingDriverChain->getAllClassNames();
+    }
+
+    public function isTransient($className)
+    {
+        return $this->baseMappingDriverChain->isTransient($className);
+    }
+
+    public function getDrivers(): array
+    {
+        return $this->baseMappingDriverChain->getDrivers();
+    }
+
+    public function getDefaultDriver(): ?MappingDriver
+    {
+        return $this->baseMappingDriverChain->getDefaultDriver();
+    }
+}

--- a/src/Doctrine/Subscriber/ORMMappedSuperClassSubscriber.php
+++ b/src/Doctrine/Subscriber/ORMMappedSuperClassSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Doctrine\Subscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber as BaseORMMappedSuperClassSubscriber;
+
+final class ORMMappedSuperClassSubscriber implements EventSubscriber
+{
+    /** @var BaseORMMappedSuperClassSubscriber */
+    private $baseOrmMappedSuperClassSubscriber;
+
+    public function __construct(BaseORMMappedSuperClassSubscriber $baseOrmMappedSuperClassSubscriber)
+    {
+        $this->baseOrmMappedSuperClassSubscriber = $baseOrmMappedSuperClassSubscriber;
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::loadClassMetadata,
+            'preEmbeddableResolve',
+        ];
+    }
+
+    public function preEmbeddableResolve(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        $this->baseOrmMappedSuperClassSubscriber->loadClassMetadata($eventArgs);
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        $this->baseOrmMappedSuperClassSubscriber->loadClassMetadata($eventArgs);
+    }
+}

--- a/src/Resources/config/doctrine/CreditMemo.orm.xml
+++ b/src/Resources/config/doctrine/CreditMemo.orm.xml
@@ -7,7 +7,7 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <entity name="Sylius\RefundPlugin\Entity\CreditMemo" table="sylius_refund_credit_memo">
+    <mapped-superclass name="Sylius\RefundPlugin\Entity\CreditMemo" table="sylius_refund_credit_memo">
         <id name="id" column="id" type="string" />
 
         <field name="number" />
@@ -26,5 +26,5 @@
         <indexes>
             <index columns="orderNumber" />
         </indexes>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/CreditMemoSequence.orm.xml
+++ b/src/Resources/config/doctrine/CreditMemoSequence.orm.xml
@@ -7,7 +7,7 @@
 
     <entity name="Sylius\RefundPlugin\Entity\CreditMemoSequence" table="sylius_refund_credit_memo_sequence">
         <id name="id" column="id" type="integer">
-            <generator strategy="AUTO" />
+            <generator/>
         </id>
         <field name="index" column="idx" type="integer" />
         <field name="version" type="integer" version="true" />

--- a/src/Resources/config/doctrine/Refund.orm.xml
+++ b/src/Resources/config/doctrine/Refund.orm.xml
@@ -7,7 +7,7 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <entity name="Sylius\RefundPlugin\Entity\Refund" table="sylius_refund_refund">
+    <mapped-superclass name="Sylius\RefundPlugin\Entity\Refund" table="sylius_refund_refund">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
@@ -16,6 +16,6 @@
         <field name="amount" type="integer" />
         <field name="refundedUnitId" type="integer" nullable="true" column="refunded_unit_id"/>
         <field name="type" />
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/RefundPayment.orm.xml
+++ b/src/Resources/config/doctrine/RefundPayment.orm.xml
@@ -7,7 +7,7 @@
                             http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <entity name="Sylius\RefundPlugin\Entity\RefundPayment" table="sylius_refund_payment">
+    <mapped-superclass name="Sylius\RefundPlugin\Entity\RefundPayment" table="sylius_refund_payment">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
@@ -20,6 +20,6 @@
         <many-to-one field="paymentMethod" target-entity="Sylius\Component\Payment\Model\PaymentMethodInterface">
             <join-column name="payment_method_id" referenced-column-name="id" nullable="true" />
         </many-to-one>
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -4,6 +4,7 @@
     <imports>
         <import resource="services/actions.xml" />
         <import resource="services/command_bus.xml" />
+        <import resource="services/doctrine.xml" />
         <import resource="services/event_bus.xml" />
         <import resource="services/generator.xml" />
         <import resource="services/provider.xml" />

--- a/src/Resources/config/services/doctrine.xml
+++ b/src/Resources/config/services/doctrine.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults autowire="false" autoconfigure="false" public="true" />
+
+        <service id="Sylius\RefundPlugin\Doctrine\Mapping\Driver\DriverChain" decorates="doctrine.orm.default_metadata_driver">
+            <argument type="service" id="Sylius\RefundPlugin\Doctrine\Mapping\Driver\DriverChain.inner" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+        </service>
+
+        <service id="Sylius\RefundPlugin\Doctrine\Subscriber\ORMMappedSuperClassSubscriber" decorates="sylius.event_subscriber.orm_mapped_super_class">
+            <argument type="service" id="Sylius\RefundPlugin\Doctrine\Subscriber\ORMMappedSuperClassSubscriber.inner" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
### Problem

It was detected on both [this](https://github.com/Sylius/RefundPlugin/pull/130) and [some other](https://github.com/Sylius/InvoicingPlugin/pull/97) plugin. If entities mapping are changed to `mapped-superclass`, embeddable relations are not resolved at all (columns are not added to entities' tables). This is, of course, a pity, as embeddables are highly useful for resolving some problems.

My first thought was that our `ORMMappedSuperClassSubscriber` from *ResourceBundle* is doing something wrong, but I've realized that class metadata passed to its `loadClassMetadata` function already has embeddable columns set (or **not set** in our case).

### Idea

The problem is in [this line from doctrine/orm package](https://github.com/doctrine/orm/blob/2.6/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L165). Apparently, mapped superclasses are not meant to be used with embeddables for some reason :/ Our subscriber is converting mapped superclasses to entities (with `convertToEntityIfNeeded` function) but it listens to `loadClassMetadata` which is thrown **after** embeddables resolving 🚀 At the end, the best idea is to use `convertToEntityIfNeeded` function before processing embeddables, but after [loading metadata for class](https://github.com/doctrine/orm/blob/2.6/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L151). 

### Solution

I've decorated the `MappingDriverChain` class to throw an event just after metadata is loaded for a class (which is still before resolving embeddables) and overwritten the `ORMMappedSuperClassSubscriber` to listen to this event and do the same as for `loadClassMetadata` event. It works 🎉 but has some drawbacks:

- doesn't it break anything? Only because tests are passing, I can't be 100% sure that the logic is correct
- our custom mapping driver *must* be named `DriverChain` not to break any gedmo extension (which is ridiculous, see https://github.com/Atlantic18/DoctrineExtensions/blob/0b7bdbefd3d166def27928dcd62ab67c11c8f172/lib/Gedmo/Mapping/ExtensionMetadataFactory.php#L136)
- because of the custom driver, we need to implement some functions that are not essential for resolving this problem (like `getDrivers()` for example)

The separated question is, if this fix is correct, where should it be done? I believe we should fix it in Sylius, but I open a PR here to show that this [is working](https://travis-ci.org/Sylius/RefundPlugin/jobs/526392238#L985) and to not litter the main Sylius repo with some potentially invalid solution 😄 

I need your help and opinion very much, to see if it's in any part the way we want to go to fix this frustrating problem 🖖 

cc @pamil @lchrusciel @bartoszpietrzak1994 @kortwotze