### PR TITLE
Symfony-extension version temporarily locked

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "behat/mink-selenium2-driver": "^1.3",
         "friends-of-behat/page-object-extension": "^0.3",
         "friends-of-behat/suite-settings-extension": "^1.0",
-        "friends-of-behat/symfony-extension": "^2.0",
+        "friends-of-behat/symfony-extension": ">=2.0 <=2.0.6",
         "friends-of-behat/variadic-extension": "^1.1",
         "lakion/mink-debug-extension": "^1.2.3",
         "leanphp/phpspec-code-coverage": "^4.2",


### PR DESCRIPTION
This should be an applicable fix until the newest versions of https://github.com/FriendsOfBehat/SymfonyExtension/issues/80 are fixed.