### PR TITLE
Improve refund UX

### DIFF
--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -1,5 +1,6 @@
 sylius_refund:
     ui:
+        clear_refunds: Clear all
         completed: Completed
         credit_memo: Credit memo
         credit_memos: Credit memos
@@ -11,9 +12,11 @@ sylius_refund:
         manage_credit_memos: Manage credit memos
         order_number: Order number
         partial_refund: Partial refund
+        refund: Refund
         refund_all: Refund all
         refund_payment_completed: Refund payment completed sucessfully
         refund_payments: Refund payments
+        refund_value: Refund value
         refunded: Refunded
         refunded_total: Refunded total
         refunds: Refunds

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -44,17 +44,17 @@
     <div class="ui stackable grid">
         <div class="sixteen wide column">
             <div class="ui segment">
-                <div id="refund-all" class="ui checkbox" style="float: right; margin-bottom: 20px;">
-                    <input type="checkbox">
-                    <label>{{ 'sylius_refund.ui.refund_all'|trans }}</label>
+                <div class="ui right aligned basic segment">
+                    <button data-refund-clear type="button" class="ui button">{{ 'sylius_refund.ui.clear_refunds'|trans }}</button>
+                    <button data-refund-all type="button" class="ui button primary">{{ 'sylius_refund.ui.refund_all'|trans }}</button>
                 </div>
                 <form action="{{ path('sylius_refund_refund_units', {'orderNumber': app.request.attributes.get('orderNumber')}) }}" method="post">
-                    <table id="refunds" class="ui compact celled definition table">
+                    <table id="refunds" class="ui compact celled table">
                         <thead>
                             <tr>
                                 <th class="wide sylius-table-column-item">{{ 'sylius.ui.order_item_product'|trans }}</th>
                                 <th class="center aligned sylius-table-column-total">{{ 'sylius.ui.total'|trans }}</th>
-                                <th class="center aligned">{{ 'sylius_refund.ui.partial_refund'|trans }}</th>
+                                <th class="center aligned">{{ 'sylius_refund.ui.refund_value'|trans }}</th>
                                 <th class="center aligned"></th>
                             </tr>
                         </thead>
@@ -81,14 +81,13 @@
 
                                         <div class="ui labeled input">
                                             <div class="ui label">{{ order.currencyCode|sylius_currency_symbol }}</div>
-                                            <input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}/>
+                                            <input data-refund-input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}/>
                                         </div>
                                     </td>
-                                    <td class="aligned collapsing">
-                                        <div class="ui checkbox {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}">
-                                            {% set checkboxName = "sylius_refund_units["~unit.id~"][full]" %}
-                                            <input type="checkbox" name="{{ checkboxName }}">
-                                        </div>
+                                    <td class="aligned collapsing">                                        
+                                        <button data-refund="{{ unit_refund_left(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT'), unit.total) }}" type="button" class="ui button primary" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %}disabled{% endif %}>
+                                            {{ 'sylius_refund.ui.refund'|trans }}
+                                        </button>
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -111,14 +110,13 @@
                                     <div class="ui labeled input">
                                         <div class="ui label">{{ order.currencyCode|sylius_currency_symbol }}</div>
                                         {% set inputName = "sylius_refund_shipments["~shipment.id~"][amount]" %}
-                                        <input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}/>
+                                        <input data-refund-input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}/>
                                     </div>
                                 </td>
                                 <td class="aligned collapsing">
-                                    <div class="ui checkbox {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}">
-                                        {% set checkboxName = "sylius_refund_shipments["~shipment.id~"][full]" %}
-                                        <input type="checkbox" name="{{ checkboxName }}">
-                                    </div>
+                                    <button data-refund="{{ unit_refund_left(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT'), shipment.amount) }}" type="button" class="ui button primary" {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}>
+                                        {{ 'sylius_refund.ui.refund'|trans }}
+                                    </button>
                                 </td>
                             </tr>
                         {% endif %}
@@ -126,34 +124,49 @@
                     </table>
 
                     {% set original_payment_method = order.payments.first().method %}
-                    <label for="payment-methods" style="font-weight: bold;">{{ 'sylius.ui.payment_method'|trans }} ({{ 'sylius.ui.original_payment_method'|trans }}: {{ original_payment_method }})</label>
-                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown" style="margin-top: 10px;">
-                        {% for payment_method in payment_methods %}
-                            <option value="{{ payment_method.id }}" {{ (payment_method.code == original_payment_method.code) ? 'selected="selected"' : '' }}>{{ payment_method.name }}</option>
-                        {% endfor %}
-                    </select>
 
-                    <br/>
-
-                    <div class="ui form">
-                        <label for="sylius-refund-comment">{{ 'sylius.ui.comment'|trans }}</label>
-                        <textarea rows="3" name="sylius_refund_comment" id="sylius-refund-comment"></textarea>
+                    <div class="ui hidden divider"></div>
+                    <div class="ui stackable grid">
+                        <div class="two column row">
+                            <div class="ui form column">
+                                <div class="field">
+                                    <label for="payment-methods">{{ 'sylius.ui.payment_method'|trans }}</label>
+                                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown">
+                                        {% for payment_method in payment_methods %}
+                                        <option value="{{ payment_method.id }}" {{ (payment_method.code == original_payment_method.code) ? 'selected="selected"' : '' }}>{{ payment_method.name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <small>{{ 'sylius.ui.original_payment_method'|trans }}: <strong>{{ original_payment_method }}</strong></small>
+                                </div>
+                            </div>
+                            <div class="ui form column">
+                                <div class="field">
+                                    <label for="sylius-refund-comment">{{ 'sylius.ui.comment'|trans }}</label>
+                                    <textarea rows="3" name="sylius_refund_comment" id="sylius-refund-comment"></textarea>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
-                    <br/>
-
-                    <div class="ui buttons">
-                        <a id="back" href="{{ path('sylius_admin_order_show', {'id': order.id}) }}" class="ui button">{{ 'sylius.ui.back'|trans }}</a>
-                        <div class="or"></div>
-                        <button class="ui primary button" type="submit">{{ 'sylius.ui.refund'|trans }}</button>
+                    <div class="ui stackable grid">
+                        <div class="two column row">
+                            <div class="column">
+                                <div class="ui buttons">
+                                    <button class="ui labeled icon primary button" type="submit"><i class="check icon"></i>{{ 'sylius.ui.refund'|trans }}</button>
+                                    <a id="back" href="{{ path('sylius_admin_order_show', {'id': order.id}) }}" class="ui button">{{ 'sylius.ui.back'|trans }}</a>
+                                </div>
+                            </div>
+                            <div class="column">
+                                <div class="ui right aligned basic segment">
+                                    <h3 id="refunded-total">
+                                        {{ 'sylius_refund.ui.refunded_total'|trans }}:
+                                        {{ money.format(order_refunded_total(order.number), order.currencyCode) }}
+                                    </h3>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-
-                    <br/><br/>
-
-                    <h3 id="refunded-total">
-                        {{ 'sylius_refund.ui.refunded_total'|trans }}:
-                        {{ money.format(order_refunded_total(order.number), order.currencyCode) }}
-                    </h3>
+                    <div class="ui hidden divider"></div>
                 </form>
             </div>
         </div>
@@ -164,18 +177,26 @@
     {{ parent() }}
     <script>
         $(document).ready(function() {
-            $('#refund-all').checkbox({
-                onChecked: function() { $('td .checkbox:not(.disabled)').checkbox('check'); },
-                onUnchecked: function() {
-                    if ($('td .checkbox:not(.checked)').length == 0) {
-                        $('td .checkbox:not(.disabled)').checkbox('uncheck');
-                    }
-                }
+            const $refundButtons = $('[data-refund]');
+            const $refundAllButton = $('[data-refund-all]');
+            const $refundClearAllButton = $('[data-refund-clear]');
+            const $refundInputs = $('[data-refund-input');
+
+            $refundButtons.on('click', function(e) {
+                const $button = $(this);
+                const refundValue = $button.attr('data-refund');
+                const $refundInput = $button.closest('tr').find('[data-refund-input]');
+
+                $refundInput.val(refundValue);
             });
 
-            $('td .checkbox').checkbox({
-                onUnchecked: function() { $('#refund-all').checkbox('uncheck'); }
-            })
+            $refundAllButton.on('click', function () {
+                $refundButtons.not(':disabled').trigger('click');
+            });
+
+            $refundClearAllButton.on('click', function () {
+                $refundInputs.val('');
+            });
         });
     </script>
 {% endblock %}

--- a/src/Twig/OrderRefundsExtension.php
+++ b/src/Twig/OrderRefundsExtension.php
@@ -45,6 +45,10 @@ final class OrderRefundsExtension extends \Twig_Extension
                 'can_unit_be_refunded',
                 [$this, 'canUnitBeRefunded']
             ),
+            new \Twig_Function(
+                'unit_refund_left',
+                [$this, 'getUnitRefundLeft']
+            ),
         ];
     }
 
@@ -56,5 +60,10 @@ final class OrderRefundsExtension extends \Twig_Extension
     public function getUnitRefundedTotal(int $unitId, string $refundType): int
     {
         return $this->unitRefundedTotalProvider->__invoke($unitId, new RefundType($refundType));
+    }
+
+    public function getUnitRefundLeft(int $unitId, string $refundType, int $unitTotal): float
+    {
+        return ($unitTotal - $this->getUnitRefundedTotal($unitId, $refundType)) / 100;
     }
 }


### PR DESCRIPTION
Refund flow
===
A new way of entering refunds value

![refund](https://user-images.githubusercontent.com/15385420/58333365-8a4e4180-7e3d-11e9-9ea2-2b7913484509.gif)

Refund page
===
I made some small UI changes to make the interface more consistent with other admin pages
<img width="1381" alt="Zrzut ekranu 2019-05-24 o 15 42 34" src="https://user-images.githubusercontent.com/15385420/58333389-963a0380-7e3d-11e9-8dd2-ba88cee4ca4f.png">
