### PR TITLE
Fix UNIQ_DEF86A0EE8F826668CDE5729 creation

### DIFF
--- a/migrations/Version20180704112314.php
+++ b/migrations/Version20180704112314.php
@@ -14,7 +14,7 @@ final class Version20180704112314 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_refund_refund (id INT AUTO_INCREMENT NOT NULL, orderNumber VARCHAR(255) NOT NULL, amount INT NOT NULL, refundedUnitId INT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE sylius_refund_refund (id INT AUTO_INCREMENT NOT NULL, orderNumber VARCHAR(255) NOT NULL, amount INT NOT NULL, refundedUnitId INT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
Fix `SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes`