### PR TITLE
Require Sylius 1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "knplabs/knp-snappy-bundle": "^1.5",
         "myclabs/php-enum": "^1.7",
         "sylius/resource-bundle": "^1.6.0-RC.2",
-        "sylius/sylius": "^1.4",
+        "sylius/sylius": "^1.5",
         "symfony/messenger": "~4.3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This plugin requires `sylius/resource-bundle: ^1.6.0-RC.2` as well as `sylius/sylius: ^1.4`.
But Sylius 1.4 requires `sylius/resource-bundle: ~1.4.4`, which means this plugin is not actually compatible with Sylius 1.4.