### PR TITLE
Remove COMMENT annotation when platform is sqlite

### DIFF
--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -21,6 +21,7 @@ final class RefundEnumType extends Type
         if ($platform->getName() === 'sqlite') {
             return 'VARCHAR(256)';
         }
+
         return 'VARCHAR(256) COMMENT "sylius_refund_refund_type"';
     }
 

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -18,6 +18,9 @@ final class RefundEnumType extends Type
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
+        if ($platform->getName() === 'sqlite') {
+            return 'VARCHAR(256)';
+        }
         return 'VARCHAR(256) COMMENT "sylius_refund_refund_type"';
     }
 


### PR DESCRIPTION
The current setup crashes with:
```
  An exception occurred while executing
'CREATE TABLE sylius_refund_refund (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 
  orderNumber VARCHAR(255) NOT   
  NULL, amount INTEGER NOT NULL, refunded_unit_id INTEGER DEFAULT NULL, type   
  VARCHAR(256) COMMENT "sylius_refund_refund_type" NOT NULL --(DC2Type:sylius  
  _refund_refund_type)                                                         
  )': 
```