### PR TITLE
Make entity properties protected

### DIFF
--- a/src/Entity/CreditMemo.php
+++ b/src/Entity/CreditMemo.php
@@ -10,40 +10,40 @@ use Sylius\Component\Core\Model\ChannelInterface;
 class CreditMemo implements CreditMemoInterface
 {
     /** @var string */
-    private $id;
+    protected $id;
 
     /** @var string */
-    private $number;
+    protected $number;
 
     /** @var string */
-    private $orderNumber;
+    protected $orderNumber;
 
     /** @var int */
-    private $total;
+    protected $total;
 
     /** @var string */
-    private $currencyCode;
+    protected $currencyCode;
 
     /** @var string */
-    private $localeCode;
+    protected $localeCode;
 
     /** @var ChannelInterface */
-    private $channel;
+    protected $channel;
 
     /** @var array */
-    private $units;
+    protected $units;
 
     /** @var string */
-    private $comment;
+    protected $comment;
 
     /** @var \DateTimeInterface */
-    private $issuedAt;
+    protected $issuedAt;
 
     /** @var CustomerBillingDataInterface */
-    private $from;
+    protected $from;
 
     /** @var ShopBillingDataInterface|null */
-    private $to;
+    protected $to;
 
     public function __construct(
         string $id,

--- a/src/Entity/CreditMemoSequence.php
+++ b/src/Entity/CreditMemoSequence.php
@@ -8,13 +8,13 @@ namespace Sylius\RefundPlugin\Entity;
 class CreditMemoSequence implements SequenceInterface
 {
     /** @var int */
-    private $id;
+    protected $id;
 
     /** @var int */
-    private $index = 0;
+    protected $index = 0;
 
     /** @var int */
-    private $version = 1;
+    protected $version = 1;
 
     public function getId(): int
     {

--- a/src/Entity/CreditMemoUnit.php
+++ b/src/Entity/CreditMemoUnit.php
@@ -8,13 +8,13 @@ namespace Sylius\RefundPlugin\Entity;
 class CreditMemoUnit implements CreditMemoUnitInterface
 {
     /** @var string */
-    private $productName;
+    protected $productName;
 
     /** @var int */
-    private $total;
+    protected $total;
 
     /** @var int */
-    private $taxesTotal;
+    protected $taxesTotal;
 
     public function __construct(string $productName, int $total, int $taxesTotal)
     {

--- a/src/Entity/CustomerBillingData.php
+++ b/src/Entity/CustomerBillingData.php
@@ -8,31 +8,31 @@ namespace Sylius\RefundPlugin\Entity;
 class CustomerBillingData implements CustomerBillingDataInterface
 {
     /** @var int */
-    private $id;
+    protected $id;
 
     /** @var string */
-    private $customerName;
+    protected $customerName;
 
     /** @var string */
-    private $street;
+    protected $street;
 
     /** @var string */
-    private $postcode;
+    protected $postcode;
 
     /** @var string */
-    private $countryCode;
+    protected $countryCode;
 
     /** @var string */
-    private $city;
+    protected $city;
 
     /** @var string|null */
-    private $company;
+    protected $company;
 
     /** @var string|null */
-    private $provinceName;
+    protected $provinceName;
 
     /** @var string|null */
-    private $provinceCode;
+    protected $provinceCode;
 
     public function __construct(
         string $customerName,

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -10,19 +10,19 @@ use Sylius\RefundPlugin\Model\RefundType;
 class Refund implements RefundInterface
 {
     /** @var int|null */
-    private $id;
+    protected $id;
 
     /** @var string */
-    private $orderNumber;
+    protected $orderNumber;
 
     /** @var int */
-    private $amount;
+    protected $amount;
 
     /** @var int */
-    private $refundedUnitId;
+    protected $refundedUnitId;
 
     /** @var RefundType */
-    private $type;
+    protected $type;
 
     public function __construct(string $orderNumber, int $amount, int $refundedUnitId, RefundType $type)
     {

--- a/src/Entity/RefundPayment.php
+++ b/src/Entity/RefundPayment.php
@@ -10,22 +10,22 @@ use Sylius\Component\Core\Model\PaymentMethodInterface;
 class RefundPayment implements RefundPaymentInterface
 {
     /** @var int */
-    private $id;
+    protected $id;
 
     /** @var string */
-    private $orderNumber;
+    protected $orderNumber;
 
     /** @var int */
-    private $amount;
+    protected $amount;
 
     /** @var string */
-    private $currencyCode;
+    protected $currencyCode;
 
     /** @var string */
-    private $state;
+    protected $state;
 
     /** @var PaymentMethodInterface */
-    private $paymentMethod;
+    protected $paymentMethod;
 
     public function __construct(
         string $orderNumber,

--- a/src/Entity/ShopBillingData.php
+++ b/src/Entity/ShopBillingData.php
@@ -8,25 +8,25 @@ namespace Sylius\RefundPlugin\Entity;
 class ShopBillingData implements ShopBillingDataInterface
 {
     /** @var int */
-    private $id;
+    protected $id;
 
     /** @var string|null */
-    private $company;
+    protected $company;
 
     /** @var string|null */
-    private $taxId;
+    protected $taxId;
 
     /** @var string|null */
-    private $countryCode;
+    protected $countryCode;
 
     /** @var string|null */
-    private $street;
+    protected $street;
 
     /** @var string|null */
-    private $city;
+    protected $city;
 
     /** @var string|null */
-    private $postcode;
+    protected $postcode;
 
     public function __construct(
         ?string $company,


### PR DESCRIPTION
Extending entities is a pain if the properties are private. Doctrine complains about them not existing on the entity.