### PR TITLE
Set default messenger bus

### DIFF
--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -19,6 +19,7 @@ sylius_mailer:
 
 framework:
     messenger:
+        default_bus: sylius_refund_plugin.command_bus
         buses:
             sylius_refund_plugin.command_bus: ~
             sylius_refund_plugin.event_bus:


### PR DESCRIPTION
Prevents the following error: `Invalid configuration for path "framework.messenger": You must specify the "default_bus" if you define more than one bus.`