### PR TITLE
Fix 'Unknown "locale" filter' error

### DIFF
--- a/src/Resources/views/_header.html.twig
+++ b/src/Resources/views/_header.html.twig
@@ -18,7 +18,7 @@
                             {{ order.currencyCode }}
                         </div>
                         <div class="item">
-                            {{ flags.fromLocaleCode(order.localeCode) }}{{ order.localeCode|locale }}
+                            {{ flags.fromLocaleCode(order.localeCode) }}{{ order.localeCode|sylius_locale_name }}
                         </div>
                         <div class="item">
                             {{ 'sylius.ui.purchased_from'|trans }}


### PR DESCRIPTION
Close #201. According to my tests, it's the only change needed to make this plugin compatible with 1.7