### PR TITLE
Fix wrong type error if the error in some cases

### DIFF
--- a/src/Action/Admin/RefundUnitsAction.php
+++ b/src/Action/Admin/RefundUnitsAction.php
@@ -70,7 +70,7 @@ final class RefundUnitsAction
         ));
     }
 
-    private function provideErrorMessage(\Exception $previousException): void
+    private function provideErrorMessage(\Throwable $previousException): void
     {
         if ($previousException instanceof InvalidRefundAmountException) {
             $this->session->getFlashBag()->add('error', $previousException->getMessage());


### PR DESCRIPTION
Problem
-------

The raised error may be a throwable since the user is supposed to add its custom code with handlers. But since this is type hinted Exception, the real failure will be hidden by this new TypeError.

Solution
--------

Accept Throwable instead.

Fixes #208