### PR TITLE
Remove wrong factory from configuration

### DIFF
--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -14,7 +14,6 @@ sylius_resource:
         sylius_refund.refund:
             classes:
                 model: Sylius\RefundPlugin\Entity\Refund
-                factory: Sylius\RefundPlugin\Factory\RefundFactory
         sylius_refund.refund_payment:
             classes:
                 model: Sylius\RefundPlugin\Entity\RefundPayment

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,8 +13,10 @@
     <services>
         <defaults autowire="false" autoconfigure="false" public="true" />
 
+        <service id="Sylius\RefundPlugin\Factory\RefundFactory" />
+
         <service id="Sylius\RefundPlugin\Creator\RefundCreator">
-            <argument type="service" id="sylius_refund.factory.refund" />
+            <argument type="service" id="Sylius\RefundPlugin\Factory\RefundFactory" />
             <argument type="service" id="Sylius\RefundPlugin\Provider\RemainingTotalProvider" />
             <argument type="service" id="sylius_refund.manager.refund" />
         </service>


### PR DESCRIPTION
Problem
-------

The RefundFactory is not a factory designed to be used in sylius resources. As a side effect it generates invalid services and may fail.

Solution
--------

Removing the factory configuration. Since it generates wrong service configuration, it's probably not used anywhere.

Fix https://github.com/Sylius/RefundPlugin/issues/186