### PR TITLE
[DX] Easier tests for RefundUnits message

### DIFF
--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -15,6 +15,7 @@ namespace Sylius\RefundPlugin\Command;
 
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
+use Sylius\RefundPlugin\Model\UnitRefundInterface;
 use Webmozart\Assert\Assert;
 
 class RefundUnits
@@ -33,8 +34,8 @@ class RefundUnits
 
     public function __construct(string $orderNumber, array $units, array $shipments, int $paymentMethodId, string $comment)
     {
-        Assert::allIsInstanceOf($units, OrderItemUnitRefund::class);
-        Assert::allIsInstanceOf($shipments, ShipmentRefund::class);
+        Assert::allIsInstanceOf($units, UnitRefundInterface::class);
+        Assert::allIsInstanceOf($shipments, UnitRefundInterface::class);
 
         $this->orderNumber = $orderNumber;
         $this->units = $units;

--- a/src/Command/RefundUnits.php
+++ b/src/Command/RefundUnits.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Command;
 
-use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
-use Sylius\RefundPlugin\Model\ShipmentRefund;
 use Sylius\RefundPlugin\Model\UnitRefundInterface;
 use Webmozart\Assert\Assert;
 
@@ -22,10 +20,10 @@ class RefundUnits
 {
     private string $orderNumber;
 
-    /** @var array|OrderItemUnitRefund[] */
+    /** @var array|UnitRefundInterface[] */
     private array $units;
 
-    /** @var array|ShipmentRefund[] */
+    /** @var array|UnitRefundInterface[] */
     private array $shipments;
 
     private int $paymentMethodId;
@@ -49,13 +47,13 @@ class RefundUnits
         return $this->orderNumber;
     }
 
-    /** @return array|OrderItemUnitRefund[] */
+    /** @return array|UnitRefundInterface[] */
     public function units(): array
     {
         return $this->units;
     }
 
-    /** @return array|ShipmentRefund[] */
+    /** @return array|UnitRefundInterface[] */
     public function shipments(): array
     {
         return $this->shipments;


### PR DESCRIPTION
Problem
-------

The `OrderItemUnitRefund` and `ShipmentRefund` implements interfaces but the `RefundUnits` does not use the given interface. Since those classes are final the assertion was not allowing mocking classes.

Solution
--------

Asserting on interfaces instead of final classes.