### PR TITLE
Making the RefundFactory implement the factory interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,9 @@
             "Tests\\Sylius\\RefundPlugin\\": "tests/"
         }
     },
+    "conflict": {
+        "symplify/package-builder": "^8.3.25"
+    },
     "scripts": {
         "fix": [
             "vendor/bin/ecs check src/ spec/ --fix"

--- a/src/Factory/RefundFactory.php
+++ b/src/Factory/RefundFactory.php
@@ -10,6 +10,11 @@ use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundFactory implements RefundFactoryInterface
 {
+    public function createNew(): RefundInterface
+    {
+        throw new \InvalidArgumentException('This object is not default constructable.');
+    }
+
     public function createWithData(string $orderNumber, int $unitId, int $amount, RefundType $type): RefundInterface
     {
         return new Refund($orderNumber, $amount, $unitId, $type);

--- a/src/Factory/RefundFactoryInterface.php
+++ b/src/Factory/RefundFactoryInterface.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Factory;
 
+use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
 use Sylius\RefundPlugin\Model\RefundType;
 
-interface RefundFactoryInterface
+interface RefundFactoryInterface extends FactoryInterface
 {
     public function createWithData(string $orderNumber, int $unitId, int $amount, RefundType $type): RefundInterface;
 }


### PR DESCRIPTION
Reason: The `RefundFactory` is used in the Resource Controller and therefore has to has to have this method, otherwise the controller can not be loaded as a service:

`
TypeError: Argument 5 passed to Sylius\Bundle\ResourceBundle\Controller\ResourceController::__construct() must implement interface Sylius\Component\Resource\Factory\FactoryInterface, instance of Sylius\RefundPlugin\Factory\RefundFactory given
`

Fixes #186 