### PR TITLE
Fix Doctrine/Migrations configuration

### DIFF
--- a/src/DependencyInjection/SyliusRefundExtension.php
+++ b/src/DependencyInjection/SyliusRefundExtension.php
@@ -29,10 +29,15 @@ final class SyliusRefundExtension extends Extension implements PrependExtensionI
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $migrationsPath = (array) \array_pop($doctrineConfig)['migrations_paths'];
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
-                'Sylius\RefundPlugin\Migrations' => __DIR__ . '/../Migrations',
-            ],
+            'migrations_paths' => \array_merge(
+                $migrationsPath ?? [],
+                [
+                    'Sylius\RefundPlugin\Migrations' => '@SyliusRefundPlugin/Migrations',
+                ]
+            ),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [

--- a/tests/Application/config/packages/doctrine_migrations.yaml
+++ b/tests/Application/config/packages/doctrine_migrations.yaml
@@ -2,3 +2,5 @@ doctrine_migrations:
     storage:
         table_storage:
             table_name: sylius_migrations
+    migrations_paths:
+        'App\Migrations': '%kernel.project_dir%/src/Migrations/'


### PR DESCRIPTION
The same as https://github.com/Sylius/InvoicingPlugin/pull/195

Without this change, migrations are generated into the plugin's directory rather than `src/Migrations`.