### PR TITLE
[UI/UX] Refund float price

### DIFF
--- a/src/Resources/views/_shipping.html.twig
+++ b/src/Resources/views/_shipping.html.twig
@@ -18,7 +18,7 @@
             <div class="ui labeled input">
                 <div class="ui label">{{ order.currencyCode|sylius_currency_symbol }}</div>
                 {% set inputName = "sylius_refund_shipments["~shipment.id~"][amount]" %}
-                <input data-refund-input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}/>
+                <input data-refund-input type="number" step="0.01" name="{{ inputName }}" {% if not can_unit_be_refunded(shipment.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::SHIPMENT')) %} disabled{% endif %}/>
             </div>
         </td>
         <td class="aligned collapsing">

--- a/src/Resources/views/_unitInput.html.twig
+++ b/src/Resources/views/_unitInput.html.twig
@@ -3,5 +3,5 @@
 
 <div class="ui labeled input">
     <div class="ui label">{{ order.currencyCode|sylius_currency_symbol }}</div>
-    <input data-refund-input type="text" name="{{ inputName }}" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}/>
+    <input data-refund-input type="number" step="0.01" name="{{ inputName }}" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}/>
 </div>


### PR DESCRIPTION
Use number type field instead of the text type. 
The web browser will send the value formatted correctly if we use 8.5 or 8,5. 
Right now on master if we put 8,5, only 8.0 is refunded but with this fix, the decimals seperated by comma are taken into account.