### PR TITLE
Fix OrderItemsTaxesApplicator with removed units

### DIFF
--- a/spec/TaxesApplicator/OrderItemsTaxesApplicatorSpec.php
+++ b/spec/TaxesApplicator/OrderItemsTaxesApplicatorSpec.php
@@ -82,7 +82,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $taxRate->isIncludedInPrice()->willReturn(false);
 
         $orderItem->getUnits()->willReturn($units);
-        $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
+        $units->getIterator()->willReturn(new \ArrayIterator([4 => $unit1->getWrappedObject(), 5 => $unit2->getWrappedObject()]));
 
         $distributor->distribute(100, 2)->willReturn([50, 50]);
 
@@ -191,7 +191,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $taxRate->isIncludedInPrice()->willReturn(false);
 
         $orderItem->getUnits()->willReturn($units);
-        $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
+        $units->getIterator()->willReturn(new \ArrayIterator([4 => $unit1->getWrappedObject(), 5 => $unit2->getWrappedObject()]));
 
         $distributor->distribute(0, 2)->willReturn([0, 0]);
 

--- a/src/TaxesApplicator/OrderItemsTaxesApplicator.php
+++ b/src/TaxesApplicator/OrderItemsTaxesApplicator.php
@@ -75,13 +75,15 @@ final class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
             $totalTaxAmount = $this->calculator->calculate($item->getTotal(), $taxRate);
             $splitTaxes = $this->distributor->distribute($totalTaxAmount, $quantity);
 
+            $i = 0;
             /** @var OrderItemUnitInterface $unit */
-            foreach ($item->getUnits() as $index => $unit) {
-                if (0 === $splitTaxes[$index]) {
+            foreach ($item->getUnits() as $unit) {
+                if (0 === $splitTaxes[$i]) {
                     continue;
                 }
 
-                $this->addAdjustment($unit, $splitTaxes[$index], $taxRate);
+                $this->addAdjustment($unit, $splitTaxes[$i], $taxRate);
+                ++$i;
             }
         }
     }


### PR DESCRIPTION
This fixes an undefined offset error caused by holes in ArrayCollection keys after removing units.

Fixes #259