### PR TITLE
Unify custom exceptions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,9 +1,16 @@
 ### UPGRADE FROM 1.0.0-RC.7 TO 1.0.0-RC.8
 
 1. The `fully_refunded` state and the `refund` transition have been removed from `sylius_order` state machine.
-2. `Sylius\RefundPlugin\Provider\LabelBasedTaxRateProvider` has been changed to `Sylius\RefundPlugin\Provider\TaxRateProvider`.
-3. The method `Sylius\RefundPlugin\Provider\TaxRateProviderInterface` has been changed 
+
+1. `Sylius\RefundPlugin\Provider\LabelBasedTaxRateProvider` has been changed to `Sylius\RefundPlugin\Provider\TaxRateProvider`.
+
+1. The method `Sylius\RefundPlugin\Provider\TaxRateProviderInterface` has been changed 
 from `provide(OrderItemUnitInterface $orderItemUnit): ?string` to `provide(AdjustableInterface $adjustable): ?string`.
+
+1. The suffix `Exception` has been removed from classes: 
+    * `Sylius\RefundPlugin\Exception\InvalidRefundAmountException` 
+    * `Sylius\RefundPlugin\Exception\OrderNotAvailableForRefundingException`
+    * `Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException` 
 
 ### UPGRADE FROM 1.0.0-RC.5 TO 1.0.0-RC.6
 

--- a/spec/CommandHandler/RefundUnitsHandlerSpec.php
+++ b/spec/CommandHandler/RefundUnitsHandlerSpec.php
@@ -10,7 +10,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
-use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefundingException;
+use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefunding;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
 use Sylius\RefundPlugin\Refunder\RefunderInterface;
@@ -73,11 +73,11 @@ final class RefundUnitsHandlerSpec extends ObjectBehavior
 
         $refundUnitsCommandValidator
             ->validate($refundUnitsCommand)
-            ->willThrow(OrderNotAvailableForRefundingException::withOrderNumber('000222'))
+            ->willThrow(OrderNotAvailableForRefunding::withOrderNumber('000222'))
         ;
 
         $this
-            ->shouldThrow(OrderNotAvailableForRefundingException::withOrderNumber('000222'))
+            ->shouldThrow(OrderNotAvailableForRefunding::withOrderNumber('000222'))
             ->during('__invoke', [$refundUnitsCommand])
         ;
     }

--- a/spec/Creator/RefundCreatorSpec.php
+++ b/spec/Creator/RefundCreatorSpec.php
@@ -8,7 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Creator\RefundCreatorInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
-use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
+use Sylius\RefundPlugin\Exception\UnitAlreadyRefunded;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
@@ -58,7 +58,7 @@ final class RefundCreatorSpec extends ObjectBehavior
         $remainingTotalProvider->getTotalLeftToRefund(1, $refundType)->willReturn(0);
 
         $this
-            ->shouldThrow(UnitAlreadyRefundedException::class)
+            ->shouldThrow(UnitAlreadyRefunded::class)
             ->during('__invoke', ['000222', 1, 1000, $refundType])
         ;
     }

--- a/spec/Validator/RefundAmountValidatorSpec.php
+++ b/spec/Validator/RefundAmountValidatorSpec.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace spec\Sylius\RefundPlugin\Validator;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\RefundPlugin\Exception\InvalidRefundAmountException;
+use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
@@ -32,7 +32,7 @@ final class RefundAmountValidatorSpec extends ObjectBehavior
         $remainingTotalProvider->getTotalLeftToRefund(2, $refundType)->willReturn(5);
 
         $this
-            ->shouldThrow(InvalidRefundAmountException::class)
+            ->shouldThrow(InvalidRefundAmount::class)
             ->during('validateUnits', [[$correctOrderItemUnitRefund], $refundType])
         ;
     }
@@ -43,7 +43,7 @@ final class RefundAmountValidatorSpec extends ObjectBehavior
         $correctOrderItemUnitRefund = new OrderItemUnitRefund(2, 10);
 
         $this
-            ->shouldThrow(InvalidRefundAmountException::class)
+            ->shouldThrow(InvalidRefundAmount::class)
             ->during(
                 'validateUnits',
                 [

--- a/spec/Validator/RefundUnitsCommandValidatorSpec.php
+++ b/spec/Validator/RefundUnitsCommandValidatorSpec.php
@@ -7,8 +7,8 @@ namespace spec\Sylius\RefundPlugin\Validator;
 use PhpSpec\ObjectBehavior;
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
-use Sylius\RefundPlugin\Exception\InvalidRefundAmountException;
-use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefundingException;
+use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
+use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefunding;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
@@ -31,7 +31,7 @@ final class RefundUnitsCommandValidatorSpec extends ObjectBehavior
         $refundUnits = new RefundUnits('000001', [], [], 1, '');
 
         $this
-            ->shouldThrow(OrderNotAvailableForRefundingException::class)
+            ->shouldThrow(OrderNotAvailableForRefunding::class)
             ->during('validate', [$refundUnits])
         ;
     }
@@ -48,10 +48,10 @@ final class RefundUnitsCommandValidatorSpec extends ObjectBehavior
 
         $refundAmountValidator
             ->validateUnits([$orderItemUnitRefund], RefundType::orderItemUnit())
-            ->willThrow(InvalidRefundAmountException::class)
+            ->willThrow(InvalidRefundAmount::class)
         ;
 
-        $this->shouldThrow(InvalidRefundAmountException::class)->during('validate', [$refundUnits]);
+        $this->shouldThrow(InvalidRefundAmount::class)->during('validate', [$refundUnits]);
     }
 
     function it_throws_exception_when_shipment_is_not_valid(
@@ -68,9 +68,9 @@ final class RefundUnitsCommandValidatorSpec extends ObjectBehavior
 
         $refundAmountValidator
             ->validateUnits([$shipmentRefund], RefundType::shipment())
-            ->willThrow(InvalidRefundAmountException::class)
+            ->willThrow(InvalidRefundAmount::class)
         ;
 
-        $this->shouldThrow(InvalidRefundAmountException::class)->during('validate', [$refundUnits]);
+        $this->shouldThrow(InvalidRefundAmount::class)->during('validate', [$refundUnits]);
     }
 }

--- a/src/Action/Admin/RefundUnitsAction.php
+++ b/src/Action/Admin/RefundUnitsAction.php
@@ -6,7 +6,7 @@ namespace Sylius\RefundPlugin\Action\Admin;
 
 use Psr\Log\LoggerInterface;
 use Sylius\RefundPlugin\Creator\RefundUnitsCommandCreatorInterface;
-use Sylius\RefundPlugin\Exception\InvalidRefundAmountException;
+use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,7 +52,7 @@ final class RefundUnitsAction
             $this->commandBus->dispatch($this->commandCreator->fromRequest($request));
 
             $this->session->getFlashBag()->add('success', 'sylius_refund.units_successfully_refunded');
-        } catch (InvalidRefundAmountException $exception) {
+        } catch (InvalidRefundAmount $exception) {
             $this->session->getFlashBag()->add('error', $exception->getMessage());
 
             $this->logger->error($exception->getMessage());
@@ -72,7 +72,7 @@ final class RefundUnitsAction
 
     private function provideErrorMessage(\Throwable $previousException): void
     {
-        if ($previousException instanceof InvalidRefundAmountException) {
+        if ($previousException instanceof InvalidRefundAmount) {
             $this->session->getFlashBag()->add('error', $previousException->getMessage());
 
             return;

--- a/src/Creator/RefundCreator.php
+++ b/src/Creator/RefundCreator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Creator;
 
 use Doctrine\Persistence\ObjectManager;
-use Sylius\RefundPlugin\Exception\UnitAlreadyRefundedException;
+use Sylius\RefundPlugin\Exception\UnitAlreadyRefunded;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
@@ -36,7 +36,7 @@ final class RefundCreator implements RefundCreatorInterface
         $remainingTotal = $this->remainingTotalProvider->getTotalLeftToRefund($unitId, $refundType);
 
         if ($remainingTotal === 0) {
-            throw UnitAlreadyRefundedException::withIdAndOrderNumber($unitId, $orderNumber);
+            throw UnitAlreadyRefunded::withIdAndOrderNumber($unitId, $orderNumber);
         }
 
         $refund = $this->refundFactory->createWithData($orderNumber, $unitId, $amount, $refundType);

--- a/src/Creator/RefundUnitsCommandCreator.php
+++ b/src/Creator/RefundUnitsCommandCreator.php
@@ -6,7 +6,7 @@ namespace Sylius\RefundPlugin\Creator;
 
 use Sylius\RefundPlugin\Calculator\UnitRefundTotalCalculatorInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
-use Sylius\RefundPlugin\Exception\InvalidRefundAmountException;
+use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
@@ -32,7 +32,7 @@ final class RefundUnitsCommandCreator implements RefundUnitsCommandCreatorInterf
         $shipments = $this->filterEmptyRefundUnits($request->request->get('sylius_refund_shipments', []));
 
         if (count($units) === 0 && count($shipments) === 0) {
-            throw InvalidRefundAmountException::withValidationConstraint('sylius_refund.at_least_one_unit_should_be_selected_to_refund');
+            throw InvalidRefundAmount::withValidationConstraint('sylius_refund.at_least_one_unit_should_be_selected_to_refund');
         }
 
         return new RefundUnits(

--- a/src/Exception/InvalidRefundAmount.php
+++ b/src/Exception/InvalidRefundAmount.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Exception;
 
-final class InvalidRefundAmountException extends \InvalidArgumentException
+final class InvalidRefundAmount extends \InvalidArgumentException
 {
     public static function withValidationConstraint(string $validationConstraint): self
     {

--- a/src/Exception/OrderNotAvailableForRefunding.php
+++ b/src/Exception/OrderNotAvailableForRefunding.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Exception;
 
-final class OrderNotAvailableForRefundingException extends \InvalidArgumentException
+final class OrderNotAvailableForRefunding extends \InvalidArgumentException
 {
     public static function withOrderNumber(string $orderNumber): self
     {

--- a/src/Exception/UnitAlreadyRefunded.php
+++ b/src/Exception/UnitAlreadyRefunded.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Exception;
 
-final class UnitAlreadyRefundedException extends \InvalidArgumentException
+final class UnitAlreadyRefunded extends \InvalidArgumentException
 {
     public static function withIdAndOrderNumber(int $unitId, string $orderNumber): self
     {

--- a/src/Validator/RefundAmountValidator.php
+++ b/src/Validator/RefundAmountValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Validator;
 
-use Sylius\RefundPlugin\Exception\InvalidRefundAmountException;
+use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\UnitRefundInterface;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
@@ -27,7 +27,7 @@ final class RefundAmountValidator implements RefundAmountValidatorInterface
         /** @var UnitRefundInterface $unitRefund */
         foreach ($unitRefunds as $unitRefund) {
             if ($unitRefund->total() <= 0) {
-                throw InvalidRefundAmountException::withValidationConstraint(
+                throw InvalidRefundAmount::withValidationConstraint(
                     RefundUnitsValidationConstraintMessages::REFUND_AMOUNT_MUST_BE_GREATER_THAN_ZERO
                 );
             }
@@ -35,7 +35,7 @@ final class RefundAmountValidator implements RefundAmountValidatorInterface
             $unitRefundedTotal = $this->remainingTotalProvider->getTotalLeftToRefund($unitRefund->id(), $refundType);
 
             if ($unitRefund->total() > $unitRefundedTotal) {
-                throw InvalidRefundAmountException::withValidationConstraint(
+                throw InvalidRefundAmount::withValidationConstraint(
                     RefundUnitsValidationConstraintMessages::REFUND_AMOUNT_MUST_BE_LESS_THAN_AVAILABLE
                 );
             }

--- a/src/Validator/RefundUnitsCommandValidator.php
+++ b/src/Validator/RefundUnitsCommandValidator.php
@@ -6,7 +6,7 @@ namespace Sylius\RefundPlugin\Validator;
 
 use Sylius\RefundPlugin\Checker\OrderRefundingAvailabilityCheckerInterface;
 use Sylius\RefundPlugin\Command\RefundUnits;
-use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefundingException;
+use Sylius\RefundPlugin\Exception\OrderNotAvailableForRefunding;
 use Sylius\RefundPlugin\Model\RefundType;
 
 final class RefundUnitsCommandValidator implements RefundUnitsCommandValidatorInterface
@@ -28,7 +28,7 @@ final class RefundUnitsCommandValidator implements RefundUnitsCommandValidatorIn
     public function validate(RefundUnits $command): void
     {
         if (!$this->orderRefundingAvailabilityChecker->__invoke($command->orderNumber())) {
-            throw OrderNotAvailableForRefundingException::withOrderNumber($command->orderNumber());
+            throw OrderNotAvailableForRefunding::withOrderNumber($command->orderNumber());
         }
 
         $this->refundAmountValidator->validateUnits($command->units(), RefundType::orderItemUnit());


### PR DESCRIPTION
I've removed `Exception` suffix from exception classes to unify our custom exception in this plugin.