### PR TITLE
Always create RefundPayment after CreditMemo

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ as shown below:
 Online refund logic should be implemented if you need it.
 As the first try for the possible customization, you can check out `Sylius\RefundPlugin\Event\UnitsRefunded` event.
 
+## Post-refunding process
+
+After units are refunded, there are multiple other processes that should be triggered. By default, after units refund, there should be **CreditMemo** and
+**RefundPayment** generated. As they're strictly coupled with each other, **RefundPayment** is always created after the **CreditMemo**. Moreover, if **RefundPayment**
+fails, related **CreditMemo** should not be created as well.
+
+`\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` service facilitates the whole process. If you want to add one or more steps to it, you should create
+a service implementing `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface`, and register if with proper tag:
+
+```xml
+    <service id="App\ProcessManager\CustomAfterRefundProcessManager">
+        <tag name="sylius_refund.units_refunded.process_step" priority="0" />
+    </service>
+```
+
+Tagged services would be executed according to their priority (descending). 
+
 ## Security issues
 
 If you think that you have found a security issue, please do not use the issue tracker and do not post it publicly.

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ After units are refunded, there are multiple other processes that should be trig
 **RefundPayment** generated. As they're strictly coupled with each other, **RefundPayment** is always created after the **CreditMemo**. Moreover, if **RefundPayment**
 fails, related **CreditMemo** should not be created as well.
 
-`\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` service facilitates the whole process. If you want to add one or more steps to it, you should create
-a service implementing `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface`, and register if with proper tag:
+`Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` service facilitates the whole process. If you want to add one or more steps to it, you should create
+a service implementing `Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface`, and register if with proper tag:
 
-```xml
-    <service id="App\ProcessManager\CustomAfterRefundProcessManager">
-        <tag name="sylius_refund.units_refunded.process_step" priority="0" />
-    </service>
+```yaml
+    App\ProcessManager\CustomAfterRefundProcessManager:
+       tags:
+          - { name: sylius_refund.units_refunded.process_step, priority: 0 }
 ```
 
 Tagged services would be executed according to their priority (descending). 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,13 @@ is created by `Sylius\RefundPlugin\Factory\CreditMemoFactory`.
         }
     ```
 
+1. Post-units refunded process (containing credit memo and refund payment generation) was changed to synchronous step. Refund payment is therfore
+always generated after credit memo. Technical changes:
+    * `\Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager` and `\Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager` no longer 
+       directly listen to `\Sylius\RefundPlugin\Event\UnitsRefunded` event. `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` uses them to 
+       facilitate post-units refunding process.
+    * Their `__invoke` methods were replaced by `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface::next(UnitsRefunded $unitsRefunded)`. 
+
 ### UPGRADE FROM 1.0.0-RC.7 TO 1.0.0-RC.8
 
 1. The `fully_refunded` state and the `refund` transition have been removed from `sylius_order` state machine.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,12 +26,12 @@ is created by `Sylius\RefundPlugin\Factory\CreditMemoFactory`.
         }
     ```
 
-1. Post-units refunded process (containing credit memo and refund payment generation) was changed to synchronous step. Refund payment is therfore
+1. Post-units refunded process (containing credit memo and refund payment generation) was changed to synchronous step. Refund payment is therefore
 always generated after credit memo. Technical changes:
-    * `\Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager` and `\Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager` no longer 
-       directly listen to `\Sylius\RefundPlugin\Event\UnitsRefunded` event. `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` uses them to 
+    * `Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager` and `Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager` no longer 
+       directly listen to `Sylius\RefundPlugin\Event\UnitsRefunded` event. `Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager` uses them to 
        facilitate post-units refunding process.
-    * Their `__invoke` methods were replaced by `\Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface::next(UnitsRefunded $unitsRefunded)`. 
+    * Their `__invoke` methods were replaced by `Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface::next(UnitsRefunded $unitsRefunded)`. 
 
 ### UPGRADE FROM 1.0.0-RC.7 TO 1.0.0-RC.8
 

--- a/features/not_seeing_refund_payments_and_credit_memos_on_admin_order_view.feature
+++ b/features/not_seeing_refund_payments_and_credit_memos_on_admin_order_view.feature
@@ -1,8 +1,8 @@
 @refunds
 Feature: Not seeing refund payments and credit memos on admin order view
-    In order to be prevented from having incorrectly generated credit memos or refund payments
+    In order to have consistent documents and payment in a refunded order
     As an Administrator
-    I want not to see them if process fails on any step
+    I don't want to have a credit memo or refund payment generated alone
 
     Background:
         Given the store operates on a single green channel in "United States"
@@ -22,7 +22,7 @@ Feature: Not seeing refund payments and credit memos on admin order view
         And I decided to refund 1st "Mr. Meeseeks T-Shirt" product of the order "00000023" with "Space money" payment
         When I view the summary of the order "#00000023"
         Then I should not see any refund payments
-        Then I should not see any credit memos
+        And I should not see any credit memos
 
     @ui
     Scenario: Not seeing credit memo and refund payment on order view if refund generation failed
@@ -30,4 +30,4 @@ Feature: Not seeing refund payments and credit memos on admin order view
         And I decided to refund 1st "Mr. Meeseeks T-Shirt" product of the order "00000023" with "Space money" payment
         When I view the summary of the order "#00000023"
         Then I should not see any refund payments
-        Then I should not see any credit memos
+        And I should not see any credit memos

--- a/features/not_seeing_refund_payments_and_credit_memos_on_admin_order_view.feature
+++ b/features/not_seeing_refund_payments_and_credit_memos_on_admin_order_view.feature
@@ -1,0 +1,33 @@
+@refunds
+Feature: Not seeing refund payments and credit memos on admin order view
+    In order to be prevented from having incorrectly generated credit memos or refund payments
+    As an Administrator
+    I want not to see them if process fails on any step
+
+    Background:
+        Given the store operates on a single green channel in "United States"
+        And the store has a product "Mr. Meeseeks T-Shirt" priced at "$10.00"
+        And the store has a product "Angel T-Shirt" priced at "$5.00"
+        And the store allows shipping with "Galaxy Post"
+        And the store allows paying with "Space money"
+        And there is a customer "morty.smith@look-at-me.com" that placed an order "#00000023"
+        And the customer bought 2 "Mr. Meeseeks T-Shirt" products
+        And the customer chose "Galaxy Post" shipping method to "United States" with "Space money" payment
+        And the order "#00000023" is already paid
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Not seeing credit memo and refund payment on order view if credit memo generation failed
+        Given the credit memo generation is broken
+        And I decided to refund 1st "Mr. Meeseeks T-Shirt" product of the order "00000023" with "Space money" payment
+        When I view the summary of the order "#00000023"
+        Then I should not see any refund payments
+        Then I should not see any credit memos
+
+    @ui
+    Scenario: Not seeing credit memo and refund payment on order view if refund generation failed
+        Given the refund payment generation is broken
+        And I decided to refund 1st "Mr. Meeseeks T-Shirt" product of the order "00000023" with "Space money" payment
+        When I view the summary of the order "#00000023"
+        Then I should not see any refund payments
+        Then I should not see any credit memos

--- a/spec/ProcessManager/CreditMemoProcessManagerSpec.php
+++ b/spec/ProcessManager/CreditMemoProcessManagerSpec.php
@@ -9,6 +9,7 @@ use Sylius\RefundPlugin\Command\GenerateCreditMemo;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
+use Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -19,6 +20,11 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
         $this->beConstructedWith($commandBus);
     }
 
+    function it_implements_units_refunded_process_step_interface(): void
+    {
+        $this->shouldImplement(UnitsRefundedProcessStepInterface::class);
+    }
+
     function it_reacts_on_units_generated_event_and_dispatch_generate_credit_memo_command(MessageBusInterface $commandBus)
     {
         $unitRefunds = [new OrderItemUnitRefund(1, 1000), new OrderItemUnitRefund(3, 2000), new OrderItemUnitRefund(5, 3000)];
@@ -27,6 +33,6 @@ final class CreditMemoProcessManagerSpec extends ObjectBehavior
         $command = new GenerateCreditMemo('000222', 3000, $unitRefunds, $shipmentRefunds, 'Comment');
         $commandBus->dispatch($command)->willReturn(new Envelope($command))->shouldBeCalled();
 
-        $this(new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 3000, 'USD', 'Comment'));
+        $this->next(new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 3000, 'USD', 'Comment'));
     }
 }

--- a/spec/ProcessManager/RefundPaymentProcessManagerSpec.php
+++ b/spec/ProcessManager/RefundPaymentProcessManagerSpec.php
@@ -12,6 +12,7 @@ use Sylius\RefundPlugin\Event\UnitsRefunded;
 use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
+use Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface;
 use Sylius\RefundPlugin\Provider\RelatedPaymentIdProviderInterface;
 use Sylius\RefundPlugin\StateResolver\OrderFullyRefundedStateResolverInterface;
 use Symfony\Component\Messenger\Envelope;
@@ -33,6 +34,11 @@ final class RefundPaymentProcessManagerSpec extends ObjectBehavior
             $entityManager,
             $eventBus
         );
+    }
+
+    function it_implements_units_refunded_process_step_interface(): void
+    {
+        $this->shouldImplement(UnitsRefundedProcessStepInterface::class);
     }
 
     function it_reacts_on_units_refunded_event_and_creates_refund_payment(
@@ -65,6 +71,14 @@ final class RefundPaymentProcessManagerSpec extends ObjectBehavior
         $event = new RefundPaymentGenerated(10, '000222', 1000, 'USD', 1, 3);
         $eventBus->dispatch($event)->willReturn(new Envelope($event))->shouldBeCalled();
 
-        $this(new UnitsRefunded('000222', [new OrderItemUnitRefund(1, 500), new OrderItemUnitRefund(2, 500)], [new ShipmentRefund(1, 300)], 1, 1000, 'USD', 'Comment'));
+        $this->next(new UnitsRefunded(
+            '000222',
+            [new OrderItemUnitRefund(1, 500), new OrderItemUnitRefund(2, 500)],
+            [new ShipmentRefund(1, 300)],
+            1,
+            1000,
+            'USD',
+            'Comment'
+        ));
     }
 }

--- a/spec/ProcessManager/UnitsRefundedProcessManagerSpec.php
+++ b/spec/ProcessManager/UnitsRefundedProcessManagerSpec.php
@@ -17,7 +17,7 @@ final class UnitsRefundedProcessManagerSpec extends ObjectBehavior
         UnitsRefundedProcessStepInterface $creditMemoProcessManager,
         UnitsRefundedProcessStepInterface $refundPaymentProcessManager
     ): void {
-        $this->beConstructedWith($creditMemoProcessManager, $refundPaymentProcessManager);
+        $this->beConstructedWith([$creditMemoProcessManager, $refundPaymentProcessManager]);
     }
 
     function it_implements_units_refunded_process_manager_interface(): void

--- a/spec/ProcessManager/UnitsRefundedProcessManagerSpec.php
+++ b/spec/ProcessManager/UnitsRefundedProcessManagerSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\RefundPlugin\ProcessManager;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\RefundPlugin\Event\UnitsRefunded;
+use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
+use Sylius\RefundPlugin\Model\ShipmentRefund;
+use Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManagerInterface;
+use Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessStepInterface;
+
+final class UnitsRefundedProcessManagerSpec extends ObjectBehavior
+{
+    function let(
+        UnitsRefundedProcessStepInterface $creditMemoProcessManager,
+        UnitsRefundedProcessStepInterface $refundPaymentProcessManager
+    ): void {
+        $this->beConstructedWith($creditMemoProcessManager, $refundPaymentProcessManager);
+    }
+
+    function it_implements_units_refunded_process_manager_interface(): void
+    {
+        $this->shouldImplement(UnitsRefundedProcessManagerInterface::class);
+    }
+
+    function it_triggers_all_process_steps_if_all_are_successful(
+        UnitsRefundedProcessStepInterface $creditMemoProcessManager,
+        UnitsRefundedProcessStepInterface $refundPaymentProcessManager
+    ): void {
+        $unitRefunds = [new OrderItemUnitRefund(1, 1000), new OrderItemUnitRefund(3, 2000), new OrderItemUnitRefund(5, 3000)];
+        $shipmentRefunds = [new ShipmentRefund(1, 500), new ShipmentRefund(2, 1000)];
+        $event = new UnitsRefunded('000222', $unitRefunds, $shipmentRefunds, 1, 1500, 'USD', 'Comment');
+
+        $creditMemoProcessManager->next($event)->shouldBeCalled();
+        $refundPaymentProcessManager->next($event)->shouldBeCalled();
+
+        $this($event);
+    }
+}

--- a/src/ProcessManager/CreditMemoProcessManager.php
+++ b/src/ProcessManager/CreditMemoProcessManager.php
@@ -8,7 +8,7 @@ use Sylius\RefundPlugin\Command\GenerateCreditMemo;
 use Sylius\RefundPlugin\Event\UnitsRefunded;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-final class CreditMemoProcessManager
+final class CreditMemoProcessManager implements UnitsRefundedProcessStepInterface
 {
     /** @var MessageBusInterface */
     private $commandBus;
@@ -18,14 +18,14 @@ final class CreditMemoProcessManager
         $this->commandBus = $commandBus;
     }
 
-    public function __invoke(UnitsRefunded $event): void
+    public function next(UnitsRefunded $unitsRefunded): void
     {
         $this->commandBus->dispatch(new GenerateCreditMemo(
-            $event->orderNumber(),
-            $event->amount(),
-            $event->units(),
-            $event->shipments(),
-            $event->comment()
+            $unitsRefunded->orderNumber(),
+            $unitsRefunded->amount(),
+            $unitsRefunded->units(),
+            $unitsRefunded->shipments(),
+            $unitsRefunded->comment()
         ));
     }
 }

--- a/src/ProcessManager/UnitsRefundedProcessManager.php
+++ b/src/ProcessManager/UnitsRefundedProcessManager.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\ProcessManager;
+
+use Sylius\RefundPlugin\Event\UnitsRefunded;
+
+final class UnitsRefundedProcessManager implements UnitsRefundedProcessManagerInterface
+{
+    /** @var UnitsRefundedProcessStepInterface */
+    private $creditMemoProcessManager;
+
+    /** @var UnitsRefundedProcessStepInterface */
+    private $refundPaymentProcessManager;
+
+    public function __construct(
+        UnitsRefundedProcessStepInterface $creditMemoProcessManager,
+        UnitsRefundedProcessStepInterface $refundPaymentProcessManager
+    ) {
+        $this->creditMemoProcessManager = $creditMemoProcessManager;
+        $this->refundPaymentProcessManager = $refundPaymentProcessManager;
+    }
+
+    public function __invoke(UnitsRefunded $event): void
+    {
+        $this->creditMemoProcessManager->next($event);
+        $this->refundPaymentProcessManager->next($event);
+    }
+}

--- a/src/ProcessManager/UnitsRefundedProcessManager.php
+++ b/src/ProcessManager/UnitsRefundedProcessManager.php
@@ -8,23 +8,19 @@ use Sylius\RefundPlugin\Event\UnitsRefunded;
 
 final class UnitsRefundedProcessManager implements UnitsRefundedProcessManagerInterface
 {
-    /** @var UnitsRefundedProcessStepInterface */
-    private $creditMemoProcessManager;
+    /** @var iterable|UnitsRefundedProcessStepInterface[] */
+    private $steps;
 
-    /** @var UnitsRefundedProcessStepInterface */
-    private $refundPaymentProcessManager;
-
-    public function __construct(
-        UnitsRefundedProcessStepInterface $creditMemoProcessManager,
-        UnitsRefundedProcessStepInterface $refundPaymentProcessManager
-    ) {
-        $this->creditMemoProcessManager = $creditMemoProcessManager;
-        $this->refundPaymentProcessManager = $refundPaymentProcessManager;
+    public function __construct(iterable $steps)
+    {
+        $this->steps = $steps;
     }
 
     public function __invoke(UnitsRefunded $event): void
     {
-        $this->creditMemoProcessManager->next($event);
-        $this->refundPaymentProcessManager->next($event);
+        /** @var UnitsRefundedProcessStepInterface $step */
+        foreach ($this->steps as $step) {
+            $step->next($event);
+        }
     }
 }

--- a/src/ProcessManager/UnitsRefundedProcessManagerInterface.php
+++ b/src/ProcessManager/UnitsRefundedProcessManagerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\ProcessManager;
+
+use Sylius\RefundPlugin\Event\UnitsRefunded;
+
+interface UnitsRefundedProcessManagerInterface
+{
+    public function __invoke(UnitsRefunded $event): void;
+}

--- a/src/ProcessManager/UnitsRefundedProcessStepInterface.php
+++ b/src/ProcessManager/UnitsRefundedProcessStepInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\ProcessManager;
+
+use Sylius\RefundPlugin\Event\UnitsRefunded;
+
+interface UnitsRefundedProcessStepInterface
+{
+    public function next(UnitsRefunded $unitsRefunded): void;
+}

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -14,7 +14,7 @@
             class="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager"
         >
             <argument type="service" id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager" />
-            UnitsRefundedProcessManagerSpec           <argument type="service" id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager" />
+            <argument type="service" id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -9,6 +9,15 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
+        <service
+            id="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManagerInterface"
+            class="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager"
+        >
+            <argument type="service" id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager" />
+            UnitsRefundedProcessManagerSpec           <argument type="service" id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager" />
+            <tag name="messenger.message_handler" bus="sylius.event_bus" />
+        </service>
+
         <service id="Sylius\RefundPlugin\Listener\UnitRefundedEventListener">
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolver" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
@@ -21,7 +30,6 @@
 
         <service id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager">
             <argument type="service" id="sylius.command_bus" />
-            <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
         <service id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager">
@@ -30,7 +38,6 @@
             <argument type="service" id="Sylius\RefundPlugin\Factory\RefundPaymentFactory" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="sylius.event_bus" />
-            <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/event_bus.xml
+++ b/src/Resources/config/services/event_bus.xml
@@ -9,15 +9,6 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
-        <service
-            id="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManagerInterface"
-            class="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager"
-        >
-            <argument type="service" id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager" />
-            <argument type="service" id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager" />
-            <tag name="messenger.message_handler" bus="sylius.event_bus" />
-        </service>
-
         <service id="Sylius\RefundPlugin\Listener\UnitRefundedEventListener">
             <argument type="service" id="Sylius\RefundPlugin\StateResolver\OrderPartiallyRefundedStateResolver" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
@@ -28,8 +19,12 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
-        <service id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager">
-            <argument type="service" id="sylius.command_bus" />
+        <service
+            id="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManagerInterface"
+            class="Sylius\RefundPlugin\ProcessManager\UnitsRefundedProcessManager"
+        >
+            <argument type="tagged_iterator" tag="sylius_refund.units_refunded.process_step"/>
+            <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
         <service id="Sylius\RefundPlugin\ProcessManager\RefundPaymentProcessManager">
@@ -38,6 +33,12 @@
             <argument type="service" id="Sylius\RefundPlugin\Factory\RefundPaymentFactory" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="sylius.event_bus" />
+            <tag name="sylius_refund.units_refunded.process_step" priority="50" />
+        </service>
+
+        <service id="Sylius\RefundPlugin\ProcessManager\CreditMemoProcessManager">
+            <argument type="service" id="sylius.command_bus" />
+            <tag name="sylius_refund.units_refunded.process_step" priority="100" />
         </service>
     </services>
 </container>

--- a/tests/Application/config/services_test.yaml
+++ b/tests/Application/config/services_test.yaml
@@ -1,3 +1,14 @@
 imports:
     - { resource: "../../../vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml" }
     - { resource: "../../Behat/Resources/services.xml" }
+
+services:
+    Tests\Sylius\RefundPlugin\Behat\Services\Generator\FailedCreditMemoGenerator:
+        decorates: 'Sylius\RefundPlugin\Generator\CreditMemoGenerator'
+        arguments:
+            - '@Tests\Sylius\RefundPlugin\Behat\Services\Generator\FailedCreditMemoGenerator.inner'
+
+    Tests\Sylius\RefundPlugin\Behat\Services\Factory\FailedRefundPaymentFactory:
+        decorates: 'Sylius\RefundPlugin\Factory\RefundPaymentFactory'
+        arguments:
+            - '@Tests\Sylius\RefundPlugin\Behat\Services\Factory\FailedRefundPaymentFactory.inner'

--- a/tests/Behat/Context/Setup/RefundingContext.php
+++ b/tests/Behat/Context/Setup/RefundingContext.php
@@ -172,7 +172,7 @@ final class RefundingContext implements Context
      */
     public function theCreditMemoGenerationIsBroken(): void
     {
-        $this->failedCreditMemoGenerator->failCreditMemoGeneration();;
+        $this->failedCreditMemoGenerator->failCreditMemoGeneration();
     }
 
     /**
@@ -181,6 +181,19 @@ final class RefundingContext implements Context
     public function theRefundPaymentGenerationIsBroken(): void
     {
         $this->failedRefundPaymentFactory->failRefundPaymentCreation();
+    }
+
+    /**
+     * @AfterScenario
+     */
+    public function removeFailedGenerationFiles(): void
+    {
+        if (file_exists(FailedCreditMemoGenerator::FAILED_FILE)) {
+            unlink(FailedCreditMemoGenerator::FAILED_FILE);
+        }
+        if (file_exists(FailedRefundPaymentFactory::FAILED_FILE)) {
+            unlink(FailedRefundPaymentFactory::FAILED_FILE);
+        }
     }
 
     private function getUnitsWithProduct(OrderInterface $order, string $productName): array

--- a/tests/Behat/Context/Setup/RefundingContext.php
+++ b/tests/Behat/Context/Setup/RefundingContext.php
@@ -15,6 +15,8 @@ use Sylius\RefundPlugin\Command\RefundUnits;
 use Sylius\RefundPlugin\Model\OrderItemUnitRefund;
 use Sylius\RefundPlugin\Model\ShipmentRefund;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Tests\Sylius\RefundPlugin\Behat\Services\Factory\FailedRefundPaymentFactory;
+use Tests\Sylius\RefundPlugin\Behat\Services\Generator\FailedCreditMemoGenerator;
 use Webmozart\Assert\Assert;
 
 final class RefundingContext implements Context
@@ -25,10 +27,22 @@ final class RefundingContext implements Context
     /** @var MessageBusInterface */
     private $commandBus;
 
-    public function __construct(OrderRepositoryInterface $orderRepository, MessageBusInterface $commandBus)
-    {
+    /** @var FailedCreditMemoGenerator */
+    private $failedCreditMemoGenerator;
+
+    /** @var FailedRefundPaymentFactory */
+    private $failedRefundPaymentFactory;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        MessageBusInterface $commandBus,
+        FailedCreditMemoGenerator $failedCreditMemoGenerator,
+        FailedRefundPaymentFactory $failedRefundPaymentFactory
+    ) {
         $this->orderRepository = $orderRepository;
         $this->commandBus = $commandBus;
+        $this->failedCreditMemoGenerator = $failedCreditMemoGenerator;
+        $this->failedRefundPaymentFactory = $failedRefundPaymentFactory;
     }
 
     /**
@@ -151,6 +165,22 @@ final class RefundingContext implements Context
             $paymentMethod->getId(),
             ''
         ));
+    }
+
+    /**
+     * @Given the credit memo generation is broken
+     */
+    public function theCreditMemoGenerationIsBroken(): void
+    {
+        $this->failedCreditMemoGenerator->failCreditMemoGeneration();;
+    }
+
+    /**
+     * @Given the refund payment generation is broken
+     */
+    public function theRefundPaymentGenerationIsBroken(): void
+    {
+        $this->failedRefundPaymentFactory->failRefundPaymentCreation();
     }
 
     private function getUnitsWithProduct(OrderInterface $order, string $productName): array

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -7,9 +7,9 @@ namespace Tests\Sylius\RefundPlugin\Behat\Context\Ui;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
-use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Tests\Sylius\RefundPlugin\Behat\Page\Admin\Order\ShowPageInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingOrdersContext implements Context
@@ -66,6 +66,22 @@ final class ManagingOrdersContext implements Context
     public function shouldSeeRefundPaymentWithStatus(int $count, string $status): void
     {
         Assert::true($this->showPage->hasRefundPaymentsWithStatus($count, $status));
+    }
+
+    /**
+     * @Then I should not see any refund payments
+     */
+    public function shouldNotSeeAnyRefundPayments(): void
+    {
+        Assert::same($this->showPage->countRefundPayments(), 0);
+    }
+
+    /**
+     * @Then I should not see any credit memos
+     */
+    public function shouldNotSeeAnyCreditMemos(): void
+    {
+        Assert::same($this->showPage->countCreditMemos(), 0);
     }
 
     /**

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -14,6 +14,11 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
         return count($this->getDocument()->findAll('css', '#credit-memos tbody tr'));
     }
 
+    public function countRefundPayments(): int
+    {
+        return count($this->getDocument()->findAll('css', '#refund-payments tbody tr'));
+    }
+
     public function downloadCreditMemo(int $index): void
     {
         /** @var NodeElement $creditMemoRow */

--- a/tests/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/tests/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -10,6 +10,8 @@ interface ShowPageInterface extends BaseOrderShowPageInterface
 {
     public function countCreditMemos(): int;
 
+    public function countRefundPayments(): int;
+
     public function downloadCreditMemo(int $index): void;
 
     public function hasRefundsButton(): bool;

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -64,6 +64,8 @@
         <service id="Tests\Sylius\RefundPlugin\Behat\Context\Setup\RefundingContext">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.command_bus" />
+            <argument type="service" id="Tests\Sylius\RefundPlugin\Behat\Services\Generator\FailedCreditMemoGenerator" />
+            <argument type="service" id="Tests\Sylius\RefundPlugin\Behat\Services\Factory\FailedRefundPaymentFactory" />
         </service>
 
         <service id="Tests\Sylius\RefundPlugin\Behat\Context\Setup\OrderContext">

--- a/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
+++ b/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
@@ -9,6 +9,8 @@ use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
 
 final class FailedRefundPaymentFactory implements RefundPaymentFactoryInterface
 {
+    private const FAILED_FILE = __DIR__.'/refund-payment-failed.json';
+
     /** @var RefundPaymentFactoryInterface */
     private $baseRefundPaymentFactory;
 
@@ -24,8 +26,8 @@ final class FailedRefundPaymentFactory implements RefundPaymentFactoryInterface
         string $state,
         int $paymentMethodId
     ): RefundPaymentInterface {
-        if (file_exists(__DIR__.'/refund-payment-failed.json')) {
-            unlink(__DIR__.'/refund-payment-failed.json');
+        if (file_exists(self::FAILED_FILE)) {
+            unlink(self::FAILED_FILE);
 
             throw new \Exception('Refund payment creation failed');
         }
@@ -35,6 +37,6 @@ final class FailedRefundPaymentFactory implements RefundPaymentFactoryInterface
 
     public function failRefundPaymentCreation(): void
     {
-        touch(__DIR__.'/refund-payment-failed.json');
+        touch(self::FAILED_FILE);
     }
 }

--- a/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
+++ b/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\RefundPlugin\Behat\Services\Factory;
+
+use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
+use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
+
+final class FailedRefundPaymentFactory implements RefundPaymentFactoryInterface
+{
+    /** @var RefundPaymentFactoryInterface */
+    private $baseRefundPaymentFactory;
+
+    public function __construct(RefundPaymentFactoryInterface $baseRefundPaymentFactory)
+    {
+        $this->baseRefundPaymentFactory = $baseRefundPaymentFactory;
+    }
+
+    public function createWithData(
+        string $orderNumber,
+        int $amount,
+        string $currencyCode,
+        string $state,
+        int $paymentMethodId
+    ): RefundPaymentInterface {
+        if (file_exists(__DIR__.'/refund-payment-failed.json')) {
+            unlink(__DIR__.'/refund-payment-failed.json');
+
+            throw new \Exception('Refund payment creation failed');
+        }
+
+        return $this->baseRefundPaymentFactory->createWithData($orderNumber, $amount, $currencyCode, $state, $paymentMethodId);
+    }
+
+    public function failRefundPaymentCreation(): void
+    {
+        touch(__DIR__.'/refund-payment-failed.json');
+    }
+}

--- a/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
+++ b/tests/Behat/Services/Factory/FailedRefundPaymentFactory.php
@@ -9,7 +9,7 @@ use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface;
 
 final class FailedRefundPaymentFactory implements RefundPaymentFactoryInterface
 {
-    private const FAILED_FILE = __DIR__.'/refund-payment-failed.json';
+    public const FAILED_FILE = __DIR__.'/refund-payment-failed.json';
 
     /** @var RefundPaymentFactoryInterface */
     private $baseRefundPaymentFactory;

--- a/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
+++ b/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
@@ -10,6 +10,8 @@ use Sylius\RefundPlugin\Generator\CreditMemoGeneratorInterface;
 
 final class FailedCreditMemoGenerator implements CreditMemoGeneratorInterface
 {
+    private const FAILED_FILE = __DIR__.'/credit-memo-failed.json';
+
     /** @var CreditMemoGeneratorInterface */
     private $baseCreditMemoGenerator;
 
@@ -25,8 +27,8 @@ final class FailedCreditMemoGenerator implements CreditMemoGeneratorInterface
         array $shipments,
         string $comment
     ): CreditMemoInterface {
-        if (file_exists(__DIR__.'/credit-memo-failed.json')) {
-            unlink(__DIR__.'/credit-memo-failed.json');
+        if (file_exists(self::FAILED_FILE)) {
+            unlink(self::FAILED_FILE);
 
             throw new \Exception('Credit memo generation failed');
         }
@@ -36,6 +38,6 @@ final class FailedCreditMemoGenerator implements CreditMemoGeneratorInterface
 
     public function failCreditMemoGeneration(): void
     {
-        touch(__DIR__.'/credit-memo-failed.json');
+        touch(self::FAILED_FILE);
     }
 }

--- a/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
+++ b/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
@@ -10,7 +10,7 @@ use Sylius\RefundPlugin\Generator\CreditMemoGeneratorInterface;
 
 final class FailedCreditMemoGenerator implements CreditMemoGeneratorInterface
 {
-    private const FAILED_FILE = __DIR__.'/credit-memo-failed.json';
+    public const FAILED_FILE = __DIR__.'/credit-memo-failed.json';
 
     /** @var CreditMemoGeneratorInterface */
     private $baseCreditMemoGenerator;

--- a/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
+++ b/tests/Behat/Services/Generator/FailedCreditMemoGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\RefundPlugin\Behat\Services\Generator;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\RefundPlugin\Entity\CreditMemoInterface;
+use Sylius\RefundPlugin\Generator\CreditMemoGeneratorInterface;
+
+final class FailedCreditMemoGenerator implements CreditMemoGeneratorInterface
+{
+    /** @var CreditMemoGeneratorInterface */
+    private $baseCreditMemoGenerator;
+
+    public function __construct(CreditMemoGeneratorInterface $baseCreditMemoGenerator)
+    {
+        $this->baseCreditMemoGenerator = $baseCreditMemoGenerator;
+    }
+
+    public function generate(
+        OrderInterface $order,
+        int $total,
+        array $units,
+        array $shipments,
+        string $comment
+    ): CreditMemoInterface {
+        if (file_exists(__DIR__.'/credit-memo-failed.json')) {
+            unlink(__DIR__.'/credit-memo-failed.json');
+
+            throw new \Exception('Credit memo generation failed');
+        }
+
+        return $this->baseCreditMemoGenerator->generate($order, $total, $units, $shipments, $comment);
+    }
+
+    public function failCreditMemoGeneration(): void
+    {
+        touch(__DIR__.'/credit-memo-failed.json');
+    }
+}


### PR DESCRIPTION
Partially solves https://github.com/Sylius/RefundPlugin/issues/91

With the current implementation, both **CreditMemo** and **RefundPayment** are generated separately, which can results in a situation when one of them exists and the other does not. With the proposed change, we're protected from such a situation.

For sure, the solution is not perfect. The whole compensation/rollback functionality is based on the [DoctrineTransactionMiddleware](https://github.com/symfony/doctrine-bridge/blob/5.4/Messenger/DoctrineTransactionMiddleware.php#L37), which works in this case but does not have to be enough for some more complicated processes. A possible improvement of the proposed architecture would be adding the `prev/compensate/rollback` function to the `UnitsRefundedProcessStepInterface` to implement a more mature and reliable saga pattern 🖖 