### PR TITLE
Logo as parameter

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,11 @@
         <import resource="services/**/*.xml" />
     </imports>
 
+    <parameters>
+        <parameter key="default_logo_file">@SyliusRefundPlugin/Resources/assets/sylius-logo.png</parameter>
+        <parameter key="sylius.refund.template.logo_file">%env(default:default_logo_file:SYLIUS_REFUND_LOGO_FILE)%</parameter>
+    </parameters>
+
     <services>
         <defaults autowire="false" autoconfigure="false" public="true" />
 

--- a/src/Resources/config/services/generators.xml
+++ b/src/Resources/config/services/generators.xml
@@ -32,7 +32,7 @@
             <argument type="service" id="knp_snappy.pdf" />
             <argument type="service" id="file_locator" />
             <argument>@SyliusRefundPlugin/Download/creditMemo.html.twig</argument>
-            <argument>@SyliusRefundPlugin/Resources/assets/sylius-logo.png</argument>
+            <argument>%sylius.refund.template.logo_file%</argument>
         </service>
         <service id="Sylius\RefundPlugin\Generator\CreditMemoPdfFileGenerator" alias="Sylius\RefundPlugin\Generator\CreditMemoPdfFileGeneratorInterface">
             <deprecated>The "%alias_id%" service alias is deprecated and will be removed in RefundPlugin 1.0, use Sylius\RefundPlugin\Generator\CreditMemoPdfFileGeneratorInterface instead.</deprecated>


### PR DESCRIPTION
Inspired by PR made on Invoicing plugin(https://github.com/Sylius/InvoicingPlugin/pull/168) I decided to add logo as parameter to Refund plugin, because almost every user needs to replace the logo.