### PR TITLE
Add possibility to customize RefundType

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -80,6 +80,7 @@
 1. `sylius_refund_plugin.block_event_listener.account.order_show` and `sylius_refund_plugin.block_event_listener.order_show.credit_memos`
     listeners have been replaced by `sylius_ui` configuration
 
+<<<<<<< HEAD
 1. `Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface` and `Sylius\RefundPlugin\Factory\RefundPaymentFactory`
     service definitions have been removed and replaced by default resource factory `sylius_refund.factory.refund_payment`
 
@@ -131,6 +132,137 @@
     -       $this->unitRefundTotalCalculator = $unitRefundTotalCalculator;
     +       $this->refundUnitsConverter = $refundUnitsConverter;
         }
+    ```
+
+1. The constructor of `Sylius\RefundPlugin\Twig\OrderRefundsExtension` has been changed:
+
+    ```diff
+        public function __construct(
+            OrderRefundedTotalProviderInterface $orderRefundedTotalProvider,
+            UnitRefundedTotalProviderInterface $unitRefundedTotalProvider,
+            UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
+            OrderRepositoryInterface $orderRepository,
+            RepositoryInterface $refundPaymentRepository
+            RepositoryInterface $refundPaymentRepository,
+    +       RefundTypeFactoryInterface $refundTypeFactory
+        ) {
+            ...
+        }
+    ```
+
+1. The `__invoke` method of `Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityChecker` and `Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface` has been changed:
+
+    ```diff
+        public function __invoke(
+            int $unitId, 
+    -        RefundType $refundType
+    +        RefundTypeInterface $refundType
+        )
+        ...
+    ```
+
+
+1. The `__invoke` method of `Sylius\RefundPlugin\Creator\RefundCreator` and `Sylius\RefundPlugin\Creator\RefundCreatorInterface` has been changed:
+
+    ```diff
+        public function __invoke(
+            string $orderNumber, 
+            int $unitId, 
+            int $amount, 
+    -        RefundType $refundType
+    +        RefundTypeInterface $refundType
+       )
+        ...
+    ```
+
+1. The `__invoke` method of `Sylius\RefundPlugin\Entity\Refund` and `Sylius\RefundPlugin\Entity\RefundInterface` has been changed:
+
+    ```diff
+        public function __invoke(
+            OrderInterface $order, 
+            int $amount, 
+            int $refundedUnitId, 
+    -       RefundType $type
+    +       RefundTypeInterface $type
+       )
+        ...
+    ```
+
+1. Return type on `getType` method of `Sylius\RefundPlugin\Entity\Refund` and `Sylius\RefundPlugin\Entity\RefundInterface` has been changed from `RefundType` to `RefundTypeInterface`
+
+1. Return type on `convertToPHPValue` method of `Sylius\RefundPlugin\Entity\Type\RefundEnumType` has been changed from `RefundType` to `RefundTypeInterface`
+
+1. The `__createWithData` method of `Sylius\RefundPlugin\Factory\RefundFactory` and `Sylius\RefundPlugin\Factory\RefundFactoryInterface` has been changed:            int $unitId,
+            int $amount,
+    -       RefundType $type
+    +       RefundTypeInterface $type
+        ): RefundInterface 
+        ...
+    ```
+   
+1. `Sylius\RefundPlugin\Model\RefundType` implements `Sylius\RefundPlugin\Model\RefundTypeInterface` and consts `ORDER_ITEM_UNIT` and `SHIPMENT` has been moved to `RefundTypeInterface`
+
+1. The `getTotalLeftToRefund` method of `Sylius\RefundPlugin\Provider\RemainingTotalProvider` and `Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface` has been changed:
+
+    ```diff
+        public function getTotalLeftToRefund(
+            int $id, 
+    -       RefundType $type
+    +       RefundTypeInterface $type
+        ): int
+        ...
+    ```
+
+1. The `__invoke` method of `Sylius\RefundPlugin\Provider\UnitRefundedTotalProvider` and `Sylius\RefundPlugin\Provider\UnitRefundedTotalProviderInterface` has been changed:
+
+    ```diff
+        public function __invoke(
+            int $unitId,    
+    -       RefundType $type
+    +       RefundTypeInterface $type
+        ): int
+        ...
+    ```
+
+1. Service `Sylius\RefundPlugin\Twig\OrderRefundsExtension` has been changed:
+
+    ```diff
+        <service id="Sylius\RefundPlugin\Twig\OrderRefundsExtension">
+            <argument type="service" id="Sylius\RefundPlugin\Provider\OrderRefundedTotalProviderInterface" />
+            <argument type="service" id="Sylius\RefundPlugin\Provider\UnitRefundedTotalProviderInterface" />
+            <argument type="service" id="Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface" />
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius_refund.repository.refund_payment" />
+    +       <argument type="service" id="Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface" />
+            <tag name="twig.extension"/>
+        </service>
+    ```
+
+1. The constructor of `Sylius\RefundPlugin\Twig\OrderRefundsExtension` has been changed:
+
+    ```diff
+        public function __construct(
+            OrderRefundedTotalProviderInterface $orderRefundedTotalProvider,
+            UnitRefundedTotalProviderInterface $unitRefundedTotalProvider,
+            UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
+            OrderRepositoryInterface $orderRepository,
+            RepositoryInterface $refundPaymentRepository
+            RepositoryInterface $refundPaymentRepository,
+    +       RefundTypeFactoryInterface $refundTypeFactory
+        ) {
+            ...
+        }
+    ```
+
+1. The `validateUnits` method of `Sylius\RefundPlugin\Validator\RefundAmountValidator` and `Sylius\RefundPlugin\Validator\RefundAmountValidatorInterface` has been changed:
+
+    ```diff
+        public function validateUnits(
+            array $unitRefunds, 
+    -       RefundType $refundType
+    +       RefundTypeInterface $refundType
+        ): void
+        ...
     ```
 
 ### UPGRADE FROM 1.0.0-RC.9 TO 1.0.0-RC.10

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -80,7 +80,6 @@
 1. `sylius_refund_plugin.block_event_listener.account.order_show` and `sylius_refund_plugin.block_event_listener.order_show.credit_memos`
     listeners have been replaced by `sylius_ui` configuration
 
-<<<<<<< HEAD
 1. `Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface` and `Sylius\RefundPlugin\Factory\RefundPaymentFactory`
     service definitions have been removed and replaced by default resource factory `sylius_refund.factory.refund_payment`
 
@@ -150,79 +149,21 @@
         }
     ```
 
-1. The `__invoke` method of `Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityChecker` and `Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface` has been changed:
-
-    ```diff
-        public function __invoke(
-            int $unitId, 
-    -        RefundType $refundType
-    +        RefundTypeInterface $refundType
-        )
-        ...
-    ```
-
-
-1. The `__invoke` method of `Sylius\RefundPlugin\Creator\RefundCreator` and `Sylius\RefundPlugin\Creator\RefundCreatorInterface` has been changed:
-
-    ```diff
-        public function __invoke(
-            string $orderNumber, 
-            int $unitId, 
-            int $amount, 
-    -        RefundType $refundType
-    +        RefundTypeInterface $refundType
-       )
-        ...
-    ```
-
-1. The `__invoke` method of `Sylius\RefundPlugin\Entity\Refund` and `Sylius\RefundPlugin\Entity\RefundInterface` has been changed:
-
-    ```diff
-        public function __invoke(
-            OrderInterface $order, 
-            int $amount, 
-            int $refundedUnitId, 
-    -       RefundType $type
-    +       RefundTypeInterface $type
-       )
-        ...
-    ```
-
 1. Return type on `getType` method of `Sylius\RefundPlugin\Entity\Refund` and `Sylius\RefundPlugin\Entity\RefundInterface` has been changed from `RefundType` to `RefundTypeInterface`
 
 1. Return type on `convertToPHPValue` method of `Sylius\RefundPlugin\Entity\Type\RefundEnumType` has been changed from `RefundType` to `RefundTypeInterface`
 
-1. The `__createWithData` method of `Sylius\RefundPlugin\Factory\RefundFactory` and `Sylius\RefundPlugin\Factory\RefundFactoryInterface` has been changed:            int $unitId,
-            int $amount,
-    -       RefundType $type
-    +       RefundTypeInterface $type
-        ): RefundInterface 
-        ...
-    ```
+1. We replaced `RefundType` with `RefundTypeInterface` in the given list of classes:
+   * `Sylius\RefundPlugin\Creator\RefundCreator`
+   * `Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityChecker`
+   * `Sylius\RefundPlugin\Entity\Type\RefundEnumType`
+   * `Sylius\RefundPlugin\Entity\Refund`
+   * `Sylius\RefundPlugin\Factory\RefundFactory`
+   * `Sylius\RefundPlugin\Provider\RemainingTotalProvider`
+   * `Sylius\RefundPlugin\Provider\UnitRefundedTotalProvider`
+   * `Sylius\RefundPlugin\Validator\RefundAmountValidator`
    
 1. `Sylius\RefundPlugin\Model\RefundType` implements `Sylius\RefundPlugin\Model\RefundTypeInterface` and consts `ORDER_ITEM_UNIT` and `SHIPMENT` has been moved to `RefundTypeInterface`
-
-1. The `getTotalLeftToRefund` method of `Sylius\RefundPlugin\Provider\RemainingTotalProvider` and `Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface` has been changed:
-
-    ```diff
-        public function getTotalLeftToRefund(
-            int $id, 
-    -       RefundType $type
-    +       RefundTypeInterface $type
-        ): int
-        ...
-    ```
-
-1. The `__invoke` method of `Sylius\RefundPlugin\Provider\UnitRefundedTotalProvider` and `Sylius\RefundPlugin\Provider\UnitRefundedTotalProviderInterface` has been changed:
-
-    ```diff
-        public function __invoke(
-            int $unitId,    
-    -       RefundType $type
-    +       RefundTypeInterface $type
-        ): int
-        ...
-    ```
 
 1. Service `Sylius\RefundPlugin\Twig\OrderRefundsExtension` has been changed:
 
@@ -252,17 +193,6 @@
         ) {
             ...
         }
-    ```
-
-1. The `validateUnits` method of `Sylius\RefundPlugin\Validator\RefundAmountValidator` and `Sylius\RefundPlugin\Validator\RefundAmountValidatorInterface` has been changed:
-
-    ```diff
-        public function validateUnits(
-            array $unitRefunds, 
-    -       RefundType $refundType
-    +       RefundTypeInterface $refundType
-        ): void
-        ...
     ```
 
 ### UPGRADE FROM 1.0.0-RC.9 TO 1.0.0-RC.10

--- a/src/Checker/UnitRefundingAvailabilityChecker.php
+++ b/src/Checker/UnitRefundingAvailabilityChecker.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Checker;
 
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
 
 final class UnitRefundingAvailabilityChecker implements UnitRefundingAvailabilityCheckerInterface
@@ -21,13 +21,12 @@ final class UnitRefundingAvailabilityChecker implements UnitRefundingAvailabilit
     /** @var RemainingTotalProviderInterface */
     private $remainingTotalProvider;
 
-    public function __construct(
-        RemainingTotalProviderInterface $remainingTotalProvider
-    ) {
+    public function __construct(RemainingTotalProviderInterface $remainingTotalProvider)
+    {
         $this->remainingTotalProvider = $remainingTotalProvider;
     }
 
-    public function __invoke(int $unitId, RefundType $refundType): bool
+    public function __invoke(int $unitId, RefundTypeInterface $refundType): bool
     {
         return $this->remainingTotalProvider->getTotalLeftToRefund($unitId, $refundType) > 0;
     }

--- a/src/Checker/UnitRefundingAvailabilityCheckerInterface.php
+++ b/src/Checker/UnitRefundingAvailabilityCheckerInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Checker;
 
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface UnitRefundingAvailabilityCheckerInterface
 {
-    public function __invoke(int $unitId, RefundType $refundType): bool;
+    public function __invoke(int $unitId, RefundTypeInterface $refundType): bool;
 }

--- a/src/Creator/RefundCreator.php
+++ b/src/Creator/RefundCreator.php
@@ -18,7 +18,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\RefundPlugin\Exception\UnitAlreadyRefunded;
 use Sylius\RefundPlugin\Factory\RefundFactoryInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
 use Webmozart\Assert\Assert;
 
@@ -48,7 +48,7 @@ final class RefundCreator implements RefundCreatorInterface
         $this->refundManager = $refundManager;
     }
 
-    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundType $refundType): void
+    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundTypeInterface $refundType): void
     {
         /** @var OrderInterface|null $order */
         $order = $this->orderRepository->findOneByNumber($orderNumber);

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Entity;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 class Refund implements RefundInterface
 {
@@ -30,10 +30,10 @@ class Refund implements RefundInterface
     /** @var int */
     protected $refundedUnitId;
 
-    /** @var RefundType */
+    /** @var RefundTypeInterface */
     protected $type;
 
-    public function __construct(OrderInterface $order, int $amount, int $refundedUnitId, RefundType $type)
+    public function __construct(OrderInterface $order, int $amount, int $refundedUnitId, RefundTypeInterface $type)
     {
         $this->order = $order;
         $this->amount = $amount;
@@ -66,7 +66,7 @@ class Refund implements RefundInterface
         return $this->refundedUnitId;
     }
 
-    public function getType(): RefundType
+    public function getType(): RefundTypeInterface
     {
         return $this->type;
     }

--- a/src/Entity/RefundInterface.php
+++ b/src/Entity/RefundInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\RefundPlugin\Entity;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface RefundInterface extends ResourceInterface
 {
@@ -28,5 +28,5 @@ interface RefundInterface extends ResourceInterface
 
     public function getRefundedUnitId(): int;
 
-    public function getType(): RefundType;
+    public function getType(): RefundTypeInterface;
 }

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -33,10 +33,10 @@ class RefundEnumType extends Type
 
     public function convertToPHPValue($value, AbstractPlatform $platform): RefundTypeInterface
     {
-        if ($value instanceof RefundType && !$value::isValid($value)) {
+        if ($value instanceof RefundTypeInterface && !$value::isValid($value)) {
             throw new \InvalidArgumentException(sprintf(
                 'The value "%s" is not valid for the enum "%s". Expected one of ["%s"]',
-                $value,
+                (string) $value->getValue(),
                 RefundTypeInterface::class,
                 implode('", "', $value::keys())
             ));
@@ -52,15 +52,14 @@ class RefundEnumType extends Type
             return null;
         }
 
-        if ($value instanceof RefundType) {
+        if ($value instanceof RefundTypeInterface) {
             return (string) $value->getValue();
         }
 
         throw ConversionException::conversionFailed((string) $value, 'sylius_refund_refund_type');
     }
 
-    /** @param RefundTypeInterface|string $value */
-    protected function createType($value): RefundTypeInterface
+    protected function createType(string $value): RefundTypeInterface
     {
         return new RefundType($value);
     }

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -42,9 +42,10 @@ class RefundEnumType extends Type
             ));
         }
 
-        return new RefundType($value);
+        return $this->createType($value);
     }
 
+    /** @param mixed $value */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (null === $value) {
@@ -52,9 +53,15 @@ class RefundEnumType extends Type
         }
 
         if ($value instanceof RefundType) {
-            return (string) $value;
+            return (string) $value->getValue();
         }
 
-        throw ConversionException::conversionFailed($value, 'sylius_refund_refund_type');
+        throw ConversionException::conversionFailed((string) $value, 'sylius_refund_refund_type');
+    }
+
+    /** @param RefundTypeInterface|string $value */
+    protected function createType($value): RefundTypeInterface
+    {
+        return new RefundType($value);
     }
 }

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -17,8 +17,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
-final class RefundEnumType extends Type
+class RefundEnumType extends Type
 {
     public function getName(): string
     {
@@ -30,16 +31,15 @@ final class RefundEnumType extends Type
         return 'VARCHAR(256)';
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform): RefundType
+    public function convertToPHPValue($value, AbstractPlatform $platform): RefundTypeInterface
     {
-        if (!RefundType::isValid($value)) {
+        if ($value instanceof RefundType && !$value::isValid($value)) {
             throw new \InvalidArgumentException(sprintf(
                 'The value "%s" is not valid for the enum "%s". Expected one of ["%s"]',
                 $value,
-                RefundType::class,
-                implode('", "', RefundType::keys())
-            ))
-            ;
+                RefundTypeInterface::class,
+                implode('", "', $value::keys())
+            ));
         }
 
         return new RefundType($value);

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -16,6 +16,7 @@ namespace Sylius\RefundPlugin\Entity\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
+use MyCLabs\Enum\Enum;
 use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
@@ -33,7 +34,7 @@ class RefundEnumType extends Type
 
     public function convertToPHPValue($value, AbstractPlatform $platform): RefundTypeInterface
     {
-        if ($value instanceof RefundTypeInterface && !$value::isValid($value)) {
+        if ($value instanceof RefundTypeInterface && $value instanceof Enum && !$value::isValid($value)) {
             throw new \InvalidArgumentException(sprintf(
                 'The value "%s" is not valid for the enum "%s". Expected one of ["%s"]',
                 (string) $value->getValue(),

--- a/src/Factory/RefundFactory.php
+++ b/src/Factory/RefundFactory.php
@@ -16,7 +16,7 @@ namespace Sylius\RefundPlugin\Factory;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\RefundPlugin\Entity\Refund;
 use Sylius\RefundPlugin\Entity\RefundInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 final class RefundFactory implements RefundFactoryInterface
 {
@@ -25,8 +25,12 @@ final class RefundFactory implements RefundFactoryInterface
         throw new \InvalidArgumentException('This object is not default constructable.');
     }
 
-    public function createWithData(OrderInterface $order, int $unitId, int $amount, RefundType $type): RefundInterface
-    {
+    public function createWithData(
+        OrderInterface $order,
+        int $unitId,
+        int $amount,
+        RefundTypeInterface $type
+    ): RefundInterface {
         return new Refund($order, $amount, $unitId, $type);
     }
 }

--- a/src/Factory/RefundFactoryInterface.php
+++ b/src/Factory/RefundFactoryInterface.php
@@ -16,9 +16,14 @@ namespace Sylius\RefundPlugin\Factory;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface RefundFactoryInterface extends FactoryInterface
 {
-    public function createWithData(OrderInterface $order, int $unitId, int $amount, RefundType $type): RefundInterface;
+    public function createWithData(
+        OrderInterface $order,
+        int $unitId,
+        int $amount,
+        RefundTypeInterface $type
+    ): RefundInterface;
 }

--- a/src/Factory/RefundTypeFactory.php
+++ b/src/Factory/RefundTypeFactory.php
@@ -11,11 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Sylius\RefundPlugin\Creator;
+namespace Sylius\RefundPlugin\Factory;
 
+use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
-interface RefundCreatorInterface
+final class RefundTypeFactory implements RefundTypeFactoryInterface
 {
-    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundTypeInterface $refundType): void;
+    public function new(string $refundType): RefundTypeInterface
+    {
+        return new RefundType($refundType);
+    }
 }

--- a/src/Factory/RefundTypeFactory.php
+++ b/src/Factory/RefundTypeFactory.php
@@ -13,13 +13,20 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Factory;
 
-use Sylius\RefundPlugin\Model\RefundType;
 use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 final class RefundTypeFactory implements RefundTypeFactoryInterface
 {
-    public function new(string $refundType): RefundTypeInterface
+    /** @var string */
+    public $className;
+
+    public function __construct(string $className)
     {
-        return new RefundType($refundType);
+        $this->className = $className;
+    }
+
+    public function createNew(string $refundType): RefundTypeInterface
+    {
+        return new $this->className($refundType);
     }
 }

--- a/src/Factory/RefundTypeFactoryInterface.php
+++ b/src/Factory/RefundTypeFactoryInterface.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\RefundPlugin\Creator;
+namespace Sylius\RefundPlugin\Factory;
 
 use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
-interface RefundCreatorInterface
+interface RefundTypeFactoryInterface
 {
-    public function __invoke(string $orderNumber, int $unitId, int $amount, RefundTypeInterface $refundType): void;
+    public function new(string $refundType): RefundTypeInterface;
 }

--- a/src/Factory/RefundTypeFactoryInterface.php
+++ b/src/Factory/RefundTypeFactoryInterface.php
@@ -17,5 +17,5 @@ use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface RefundTypeFactoryInterface
 {
-    public function new(string $refundType): RefundTypeInterface;
+    public function createNew(string $refundType): RefundTypeInterface;
 }

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -27,16 +27,6 @@ class RefundType extends Enum implements RefundTypeInterface
         return new self(self::SHIPMENT);
     }
 
-    public static function keys(): array
-    {
-        return parent::keys();
-    }
-
-    public static function isValid($value): bool
-    {
-        return parent::isValid($value);
-    }
-
     /**
      * @psalm-return mixed
      */

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -15,12 +15,8 @@ namespace Sylius\RefundPlugin\Model;
 
 use MyCLabs\Enum\Enum;
 
-final class RefundType extends Enum
+class RefundType extends Enum implements RefundTypeInterface
 {
-    public const ORDER_ITEM_UNIT = 'order_item_unit';
-
-    public const SHIPMENT = 'shipment';
-
     public static function orderItemUnit(): self
     {
         return new self(self::ORDER_ITEM_UNIT);

--- a/src/Model/RefundType.php
+++ b/src/Model/RefundType.php
@@ -26,4 +26,22 @@ class RefundType extends Enum implements RefundTypeInterface
     {
         return new self(self::SHIPMENT);
     }
+
+    public static function keys(): array
+    {
+        return parent::keys();
+    }
+
+    public static function isValid($value): bool
+    {
+        return parent::isValid($value);
+    }
+
+    /**
+     * @psalm-return mixed
+     */
+    public function getValue()
+    {
+        return parent::getValue();
+    }
 }

--- a/src/Model/RefundTypeInterface.php
+++ b/src/Model/RefundTypeInterface.php
@@ -24,19 +24,7 @@ interface RefundTypeInterface
     public static function shipment(): self;
 
     /**
-     * @psalm-param mixed $variable
-     */
-    public function equals($variable = null): bool;
-
-    /**
-     * @psalm-param mixed $value
-     */
-    public static function isValid($value): bool;
-
-    /**
      * @psalm-return mixed
      */
     public function getValue();
-
-    public static function keys(): array;
 }

--- a/src/Model/RefundTypeInterface.php
+++ b/src/Model/RefundTypeInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\RefundPlugin\Model;
+
+interface RefundTypeInterface
+{
+    public const ORDER_ITEM_UNIT = 'order_item_unit';
+
+    public const SHIPMENT = 'shipment';
+
+    public static function orderItemUnit(): self;
+
+    public static function shipment(): self;
+}

--- a/src/Model/RefundTypeInterface.php
+++ b/src/Model/RefundTypeInterface.php
@@ -22,4 +22,21 @@ interface RefundTypeInterface
     public static function orderItemUnit(): self;
 
     public static function shipment(): self;
+
+    /**
+     * @psalm-param mixed $variable
+     */
+    public function equals($variable = null): bool;
+
+    /**
+     * @psalm-param mixed $value
+     */
+    public static function isValid($value): bool;
+
+    /**
+     * @psalm-return mixed
+     */
+    public function getValue();
+
+    public static function keys(): array;
 }

--- a/src/Provider/RemainingTotalProvider.php
+++ b/src/Provider/RemainingTotalProvider.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
+use MyCLabs\Enum\Enum;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Order\Model\AdjustableInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
 use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 use Webmozart\Assert\Assert;
 
 final class RemainingTotalProvider implements RemainingTotalProviderInterface
@@ -42,7 +44,7 @@ final class RemainingTotalProvider implements RemainingTotalProviderInterface
         $this->refundRepository = $refundRepository;
     }
 
-    public function getTotalLeftToRefund(int $id, RefundType $type): int
+    public function getTotalLeftToRefund(int $id, RefundTypeInterface $type): int
     {
         $unitTotal = $this->getRefundUnitTotal($id, $type);
         $refunds = $this->refundRepository->findBy(['refundedUnitId' => $id, 'type' => $type]);
@@ -60,9 +62,9 @@ final class RemainingTotalProvider implements RemainingTotalProviderInterface
         return $unitTotal - $refundedTotal;
     }
 
-    private function getRefundUnitTotal(int $id, RefundType $refundType): int
+    private function getRefundUnitTotal(int $id, RefundTypeInterface $refundType): int
     {
-        if ($refundType->equals(RefundType::orderItemUnit())) {
+        if ($refundType instanceof Enum && $refundType->equals(RefundType::orderItemUnit())) {
             /** @var OrderItemUnitInterface $orderItemUnit */
             $orderItemUnit = $this->orderItemUnitRepository->find($id);
             Assert::notNull($orderItemUnit);

--- a/src/Provider/RemainingTotalProvider.php
+++ b/src/Provider/RemainingTotalProvider.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
-use MyCLabs\Enum\Enum;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Order\Model\AdjustableInterface;
@@ -64,7 +63,7 @@ final class RemainingTotalProvider implements RemainingTotalProviderInterface
 
     private function getRefundUnitTotal(int $id, RefundTypeInterface $refundType): int
     {
-        if ($refundType instanceof Enum && $refundType->equals(RefundType::orderItemUnit())) {
+        if ($refundType->equals(RefundType::orderItemUnit())) {
             /** @var OrderItemUnitInterface $orderItemUnit */
             $orderItemUnit = $this->orderItemUnitRepository->find($id);
             Assert::notNull($orderItemUnit);

--- a/src/Provider/RemainingTotalProvider.php
+++ b/src/Provider/RemainingTotalProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
+use MyCLabs\Enum\Enum;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Order\Model\AdjustableInterface;
@@ -63,7 +64,7 @@ final class RemainingTotalProvider implements RemainingTotalProviderInterface
 
     private function getRefundUnitTotal(int $id, RefundTypeInterface $refundType): int
     {
-        if ($refundType->equals(RefundType::orderItemUnit())) {
+        if ($refundType instanceof Enum && $refundType->equals(RefundType::orderItemUnit())) {
             /** @var OrderItemUnitInterface $orderItemUnit */
             $orderItemUnit = $this->orderItemUnitRepository->find($id);
             Assert::notNull($orderItemUnit);

--- a/src/Provider/RemainingTotalProviderInterface.php
+++ b/src/Provider/RemainingTotalProviderInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface RemainingTotalProviderInterface
 {
-    public function getTotalLeftToRefund(int $id, RefundType $type): int;
+    public function getTotalLeftToRefund(int $id, RefundTypeInterface $type): int;
 }

--- a/src/Provider/UnitRefundedTotalProvider.php
+++ b/src/Provider/UnitRefundedTotalProvider.php
@@ -15,7 +15,7 @@ namespace Sylius\RefundPlugin\Provider;
 
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Entity\RefundInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 final class UnitRefundedTotalProvider implements UnitRefundedTotalProviderInterface
 {
@@ -27,7 +27,7 @@ final class UnitRefundedTotalProvider implements UnitRefundedTotalProviderInterf
         $this->refundRepository = $refundRepository;
     }
 
-    public function __invoke(int $unitId, RefundType $type): int
+    public function __invoke(int $unitId, RefundTypeInterface $type): int
     {
         $refunds = $this->refundRepository->findBy(['refundedUnitId' => $unitId, 'type' => $type]);
 

--- a/src/Provider/UnitRefundedTotalProviderInterface.php
+++ b/src/Provider/UnitRefundedTotalProviderInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Provider;
 
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface UnitRefundedTotalProviderInterface
 {
-    public function __invoke(int $unitId, RefundType $type): int;
+    public function __invoke(int $unitId, RefundTypeInterface $type): int;
 }

--- a/src/Refunder/OrderItemUnitsRefunder.php
+++ b/src/Refunder/OrderItemUnitsRefunder.php
@@ -41,7 +41,12 @@ final class OrderItemUnitsRefunder implements RefunderInterface
 
         /** @var UnitRefundInterface $unit */
         foreach ($units as $unit) {
-            $this->refundCreator->__invoke($orderNumber, $unit->id(), $unit->total(), RefundType::orderItemUnit());
+            $this->refundCreator->__invoke(
+                $orderNumber,
+                $unit->id(),
+                $unit->total(),
+                RefundType::orderItemUnit()
+            );
 
             $refundedTotal += $unit->total();
 

--- a/src/Refunder/OrderShipmentsRefunder.php
+++ b/src/Refunder/OrderShipmentsRefunder.php
@@ -39,7 +39,12 @@ final class OrderShipmentsRefunder implements RefunderInterface
 
         /** @var ShipmentRefund $shipmentUnit */
         foreach ($units as $shipmentUnit) {
-            $this->refundCreator->__invoke($orderNumber, $shipmentUnit->id(), $shipmentUnit->total(), RefundType::shipment());
+            $this->refundCreator->__invoke(
+                $orderNumber,
+                $shipmentUnit->id(),
+                $shipmentUnit->total(),
+                RefundType::shipment()
+            );
 
             $refundedTotal += $shipmentUnit->total();
 

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -1,5 +1,5 @@
 parameters:
-    sylius_refund.refund_type: Sylius\RefundPlugin\Entity\Type\RefundEnumType
+    sylius_refund.refund_enum_type: Sylius\RefundPlugin\Entity\Type\RefundEnumType
 
 sylius_resource:
     resources:
@@ -158,4 +158,4 @@ sylius_ui:
 doctrine:
     dbal:
         types:
-            sylius_refund_refund_type: "%sylius_refund.refund_type%"
+            sylius_refund_refund_type: "%sylius_refund.refund_enum_type%"

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -1,3 +1,6 @@
+parameters:
+    sylius_refund.refund_type: Sylius\RefundPlugin\Entity\Type\RefundEnumType
+
 sylius_resource:
     resources:
         sylius_refund.credit_memo:
@@ -155,4 +158,4 @@ sylius_ui:
 doctrine:
     dbal:
         types:
-            sylius_refund_refund_type: Sylius\RefundPlugin\Entity\Type\RefundEnumType
+            sylius_refund_refund_type: "%sylius_refund.refund_type%"

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -1,5 +1,6 @@
 parameters:
     sylius_refund.refund_enum_type: Sylius\RefundPlugin\Entity\Type\RefundEnumType
+    sylius_refund.refund_type: Sylius\RefundPlugin\Model\RefundType
 
 sylius_resource:
     resources:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius_refund.repository.refund_payment" />
+            <argument type="service" id="Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface" />
             <tag name="twig.extension"/>
         </service>
 

--- a/src/Resources/config/services/factories.xml
+++ b/src/Resources/config/services/factories.xml
@@ -12,7 +12,9 @@
             <deprecated>The "%alias_id%" service alias is deprecated and will be removed in RefundPlugin 1.0, use Sylius\RefundPlugin\Factory\CreditMemoSequenceFactoryInterface instead.</deprecated>
         </service>
 
-        <service id="Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface" class="Sylius\RefundPlugin\Factory\RefundTypeFactory" />
+        <service id="Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface" class="Sylius\RefundPlugin\Factory\RefundTypeFactory">
+            <argument type="string">%sylius_refund.refund_type%</argument>
+        </service>
         <service id="Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface" class="Sylius\RefundPlugin\Factory\RefundPaymentFactory">
             <argument type="service" id="sylius.repository.payment_method" />
         </service>

--- a/src/Resources/config/services/factories.xml
+++ b/src/Resources/config/services/factories.xml
@@ -12,6 +12,14 @@
             <deprecated>The "%alias_id%" service alias is deprecated and will be removed in RefundPlugin 1.0, use Sylius\RefundPlugin\Factory\CreditMemoSequenceFactoryInterface instead.</deprecated>
         </service>
 
+        <service id="Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface" class="Sylius\RefundPlugin\Factory\RefundTypeFactory" />
+        <service id="Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface" class="Sylius\RefundPlugin\Factory\RefundPaymentFactory">
+            <argument type="service" id="sylius.repository.payment_method" />
+        </service>
+        <service id="Sylius\RefundPlugin\Factory\RefundPaymentFactory" alias="Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface">
+            <deprecated>The "%alias_id%" service alias is deprecated and will be removed in RefundPlugin 1.0, use Sylius\RefundPlugin\Factory\RefundPaymentFactoryInterface instead.</deprecated>
+        </service>
+
         <service
             id="Sylius\RefundPlugin\Factory\CreditMemoFactory"
             decorates="sylius_refund.factory.credit_memo"

--- a/src/Twig/OrderRefundsExtension.php
+++ b/src/Twig/OrderRefundsExtension.php
@@ -87,12 +87,12 @@ final class OrderRefundsExtension extends AbstractExtension
 
     public function canUnitBeRefunded(int $unitId, string $refundType): bool
     {
-        return $this->unitRefundingAvailabilityChecker->__invoke($unitId, $this->refundTypeFactory->new($refundType));
+        return $this->unitRefundingAvailabilityChecker->__invoke($unitId, $this->refundTypeFactory->createNew($refundType));
     }
 
     public function getUnitRefundedTotal(int $unitId, string $refundType): int
     {
-        return $this->unitRefundedTotalProvider->__invoke($unitId, $this->refundTypeFactory->new($refundType));
+        return $this->unitRefundedTotalProvider->__invoke($unitId, $this->refundTypeFactory->createNew($refundType));
     }
 
     public function getUnitRefundLeft(int $unitId, string $refundType, int $unitTotal): float

--- a/src/Twig/OrderRefundsExtension.php
+++ b/src/Twig/OrderRefundsExtension.php
@@ -17,7 +17,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\RefundPlugin\Checker\UnitRefundingAvailabilityCheckerInterface;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Factory\RefundTypeFactoryInterface;
 use Sylius\RefundPlugin\Provider\OrderRefundedTotalProviderInterface;
 use Sylius\RefundPlugin\Provider\UnitRefundedTotalProviderInterface;
 use Twig\Extension\AbstractExtension;
@@ -40,18 +40,23 @@ final class OrderRefundsExtension extends AbstractExtension
     /** @var RepositoryInterface */
     private $refundPaymentRepository;
 
+    /** @var RefundTypeFactoryInterface */
+    private $refundTypeFactory;
+
     public function __construct(
         OrderRefundedTotalProviderInterface $orderRefundedTotalProvider,
         UnitRefundedTotalProviderInterface $unitRefundedTotalProvider,
         UnitRefundingAvailabilityCheckerInterface $unitRefundingAvailabilityChecker,
         OrderRepositoryInterface $orderRepository,
-        RepositoryInterface $refundPaymentRepository
+        RepositoryInterface $refundPaymentRepository,
+        RefundTypeFactoryInterface $refundTypeFactory
     ) {
         $this->orderRefundedTotalProvider = $orderRefundedTotalProvider;
         $this->unitRefundedTotalProvider = $unitRefundedTotalProvider;
         $this->unitRefundingAvailabilityChecker = $unitRefundingAvailabilityChecker;
         $this->orderRepository = $orderRepository;
         $this->refundPaymentRepository = $refundPaymentRepository;
+        $this->refundTypeFactory = $refundTypeFactory;
     }
 
     public function getFunctions(): array
@@ -82,12 +87,12 @@ final class OrderRefundsExtension extends AbstractExtension
 
     public function canUnitBeRefunded(int $unitId, string $refundType): bool
     {
-        return $this->unitRefundingAvailabilityChecker->__invoke($unitId, new RefundType($refundType));
+        return $this->unitRefundingAvailabilityChecker->__invoke($unitId, $this->refundTypeFactory->new($refundType));
     }
 
     public function getUnitRefundedTotal(int $unitId, string $refundType): int
     {
-        return $this->unitRefundedTotalProvider->__invoke($unitId, new RefundType($refundType));
+        return $this->unitRefundedTotalProvider->__invoke($unitId, $this->refundTypeFactory->new($refundType));
     }
 
     public function getUnitRefundLeft(int $unitId, string $refundType, int $unitTotal): float

--- a/src/Validator/RefundAmountValidator.php
+++ b/src/Validator/RefundAmountValidator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin\Validator;
 
 use Sylius\RefundPlugin\Exception\InvalidRefundAmount;
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 use Sylius\RefundPlugin\Model\UnitRefundInterface;
 use Sylius\RefundPlugin\Provider\RemainingTotalProviderInterface;
 use Webmozart\Assert\Assert;
@@ -29,7 +29,7 @@ final class RefundAmountValidator implements RefundAmountValidatorInterface
         $this->remainingTotalProvider = $unitRefundedTotalProvider;
     }
 
-    public function validateUnits(array $unitRefunds, RefundType $refundType): void
+    public function validateUnits(array $unitRefunds, RefundTypeInterface $refundType): void
     {
         Assert::allIsInstanceOf($unitRefunds, UnitRefundInterface::class);
 

--- a/src/Validator/RefundAmountValidatorInterface.php
+++ b/src/Validator/RefundAmountValidatorInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\RefundPlugin\Validator;
 
-use Sylius\RefundPlugin\Model\RefundType;
+use Sylius\RefundPlugin\Model\RefundTypeInterface;
 
 interface RefundAmountValidatorInterface
 {
-    public function validateUnits(array $unitRefunds, RefundType $refundType): void;
+    public function validateUnits(array $unitRefunds, RefundTypeInterface $refundType): void;
 }


### PR DESCRIPTION
Fix for: #279

How to custom RefundType:

After added new RefundType and RefundTypeInterface with new features:
```
<?php

declare(strict_types=1);

namespace App\Entity;

use Sylius\RefundPlugin\Model\RefundType as BaseRefundType;

final class RefundType extends BaseRefundType implements RefundTypeInterface
{
    public static function customUnit(): RefundTypeInterface
    {
        return new self(self::CUSTOM_UNIT);
    }
}
```

```
<?php

declare(strict_types=1);

namespace App\Entity;

use Sylius\RefundPlugin\Model\RefundTypeInterface as BaseRefundTypeInterface;

interface RefundTypeInterface extends BaseRefundTypeInterface
{
    public const CUSTOM_UNIT = 'custom_unit';

    public static function customUnit(): self;
}
```

You have to:

- Overwrite `RefundEnumType` and createType() method for creating new `RefundType`:

```
<?php

declare(strict_types=1);

namespace App\Entity\Type;

use App\Entity\RefundType;
use Sylius\RefundPlugin\Entity\Type\RefundEnumType as BaseRefundEnumType;
use Sylius\RefundPlugin\Model\RefundTypeInterface;

class RefundEnumType extends BaseRefundEnumType
{
    protected function createType($value): RefundTypeInterface
    {
        return new RefundType($value);
    }
}
```

Overwrite `sylius_refund.refund_enum_type` key with new `RefundEnumType`: `App\Entity\Type\RefundEnumType`
and `sylius_refund.refund_type` key with new `RefundType`: ``App\Entity\Type\RefundType``
