### PR TITLE
fix for `doctrine:schema:update`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,13 @@ jobs:
                 name: Install JS dependencies
                 run: (cd tests/Application && yarn install)
 
+            -   name: Check out database schema update
+                run: |
+                    (cd tests/Application && bin/console doctrine:database:create)
+                    (cd tests/Application && bin/console doctrine:schema:update)
+                    (cd tests/Application && bin/console doctrine:schema:validate)
+                    (cd tests/Application && bin/console doctrine:database:drop --force)
+
             -
                 name: Prepare test application database
                 run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
             -   name: Check out database schema update
                 run: |
                     (cd tests/Application && bin/console doctrine:database:create)
-                    (cd tests/Application && bin/console doctrine:schema:update)
+                    (cd tests/Application && bin/console doctrine:schema:update --force)
                     (cd tests/Application && bin/console doctrine:schema:validate)
                     (cd tests/Application && bin/console doctrine:database:drop --force)
 

--- a/src/Entity/Type/RefundEnumType.php
+++ b/src/Entity/Type/RefundEnumType.php
@@ -64,4 +64,9 @@ class RefundEnumType extends Type
     {
         return new RefundType($value);
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Currently, if you install a plug-in via migrations, everything is fine.

But if you try with doctrine:schema:update, there's always a query that is executed, but not detected if you re-issue command:

ALTER TABLE sylius_refund_refund CHANGE type type VARCHAR(256) NOT NULL;
It's caused by lack of the comment for column. Having the Type definition updated solves this problem.