### PR TITLE
Resolve added to parameter to make usage of proper path possible

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,7 +10,7 @@
 
     <parameters>
         <parameter key="default_logo_file">@SyliusRefundPlugin/Resources/assets/sylius-logo.png</parameter>
-        <parameter key="sylius.refund.template.logo_file">%env(default:default_logo_file:SYLIUS_REFUND_LOGO_FILE)%</parameter>
+        <parameter key="sylius.refund.template.logo_file">%env(default:default_logo_file:resolve:SYLIUS_REFUND_LOGO_FILE)%</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 
| Bug fix?        | no
| New feature?    | no
| Related tickets | [PR](https://github.com/Sylius/Sylius/pull/13423)

In case of need to use a proper path to change the logo of the Credit Memo's we had to add "resolve" to parameter.
