### PR TITLE
[WIP] Enable local file access in CreditMemoPdfFileGenerator

### DIFF
--- a/spec/Generator/CreditMemoPdfFileGeneratorSpec.php
+++ b/spec/Generator/CreditMemoPdfFileGeneratorSpec.php
@@ -66,7 +66,7 @@ final class CreditMemoPdfFileGeneratorSpec extends ObjectBehavior
             ->willReturn('<html>I am a credit memo pdf file content</html>')
         ;
 
-        $pdfGenerator->getOutputFromHtml('<html>I am a credit memo pdf file content</html>')->willReturn('PDF FILE');
+        $pdfGenerator->getOutputFromHtml('<html>I am a credit memo pdf file content</html>', ['enable-local-file-access' => true])->willReturn('PDF FILE');
 
         $this
             ->generate('7903c83a-4c5e-4bcf-81d8-9dc304c6a353')

--- a/src/Generator/CreditMemoPdfFileGenerator.php
+++ b/src/Generator/CreditMemoPdfFileGenerator.php
@@ -68,10 +68,15 @@ final class CreditMemoPdfFileGenerator implements CreditMemoPdfFileGeneratorInte
 
         $filename = str_replace('/', '_', $number) . self::FILE_EXTENSION;
 
-        $pdf = $this->pdfGenerator->getOutputFromHtml($this->twig->render($this->template, [
-            'creditMemo' => $creditMemo,
-            'creditMemoLogoPath' => $this->fileLocator->locate($this->creditMemoLogoPath),
-        ]));
+        $pdf = $this->pdfGenerator->getOutputFromHtml(
+            $this->twig->render($this->template, [
+                'creditMemo' => $creditMemo,
+                'creditMemoLogoPath' => $this->fileLocator->locate($this->creditMemoLogoPath),
+            ]),
+            [
+                'enable-local-file-access' => true,
+            ]
+        );
 
         return new CreditMemoPdf($filename, $pdf);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| Related tickets | 

`wkhtmltopdf` disables local file access by default in the newest version (v0.12.6). This is the reason why InvoicingPlugin and RefundPlugin can’t access the logo file. The problem can be resolved with the option `enable-local-file-access` in `knp_snappy.pdf.options`. Here is the same problem on Stack Overflow: https://stackoverflow.com/questions/62315246/wkhtmltopdf-0-12-6-warning-blocked-access-to-file. I've checked it on v0.12.5 and can confirm it appears only on v0.12.6.

So now enabling local file access resolves the issue but it’s tricky and requires one more step in the installation instruction for both InvoicingPlugin and RefundPlugin. Furthermore keeping it disabled globally can be better from a security point of view. All things considered, I add this option only in `CreditMemoPdfFileGenerator`.
Please let me know if the solution is fine, then I will add a similar fix to the InvoicingPlugin :slightly_smiling_face: 