### PR TITLE
[Templates] Remove redundant template overriding

### DIFF
--- a/tests/Application/templates/bundles/SyliusAdminBundle/Order/Label/State/fully_refunded.html.twig
+++ b/tests/Application/templates/bundles/SyliusAdminBundle/Order/Label/State/fully_refunded.html.twig
@@ -1,4 +1,0 @@
-<span class="ui purple label">
-    <i class="check icon"></i>
-    {{ value|trans }}
-</span>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| Related tickets | partially https://github.com/Sylius/RefundPlugin/pull/123

`SyliusAdminBundle/Order/Label/State/fully_refunded.html.twig` file was removed in https://github.com/Sylius/RefundPlugin/pull/123, so I think we don't need this file in the test application anymore.