### PR TITLE
[Maintenance] Allow flex plugin during plugin installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,10 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2 
| Bug fix?        | yes
| New feature?    | no
| Related tickets | Follow up of https://github.com/Sylius/Sylius/pull/14106
