### PR TITLE
[Maintenance] Remove redundant configuration

### DIFF
--- a/tests/Application/Kernel.php
+++ b/tests/Application/Kernel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Sylius\RefundPlugin\Application;
 
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
-use Sylius\Bundle\CoreBundle\Application\Kernel as SyliusKernel;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
@@ -100,13 +99,6 @@ final class Kernel extends BaseKernel
     {
         $contents = require $bundlesFile;
 
-        if (SyliusKernel::MINOR_VERSION > 10) {
-            $contents = array_merge(
-                ['Sylius\Calendar\SyliusCalendarBundle' => ['all' => true]],
-                $contents
-            );
-        }
-
         foreach ($contents as $class => $envs) {
             if (isset($envs['all']) || isset($envs[$this->environment])) {
                 yield new $class();
@@ -137,7 +129,6 @@ final class Kernel extends BaseKernel
     {
         $directories = [
             $this->getProjectDir() . '/config',
-            $this->getProjectDir() . '/config/sylius/' . SyliusKernel::MAJOR_VERSION . '.' . SyliusKernel::MINOR_VERSION,
         ];
 
         return array_filter($directories, 'file_exists');

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -29,6 +29,7 @@ return [
     Sylius\Bundle\CoreBundle\SyliusCoreBundle::class => ['all' => true],
     Sylius\Bundle\ResourceBundle\SyliusResourceBundle::class => ['all' => true],
     Sylius\Bundle\GridBundle\SyliusGridBundle::class => ['all' => true],
+    Sylius\Calendar\SyliusCalendarBundle::class => ['all' => true],
     winzou\Bundle\StateMachineBundle\winzouStateMachineBundle::class => ['all' => true],
     Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
     Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle::class => ['all' => true],


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | no
| Related tickets | 

Sylius 1.10 is not supported so we can safely drop some configuration adjustments.