### PR TITLE
`SyliusTemplateEvents` introduced on the `Refund` view

### DIFF
--- a/src/Resources/config/app/events.yaml
+++ b/src/Resources/config/app/events.yaml
@@ -55,3 +55,90 @@ sylius_ui:
                     template: '@SyliusRefundPlugin/Order/Admin/CreditMemo/_downloadButton.html.twig'
                     enabled: '%sylius_refund.pdf_generator.enabled%'
                     priority: 10
+
+        sylius_refund.admin.order.refund.buttons:
+            blocks:
+                clear_all:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Button/_clearAll.html.twig'
+                    priority: 20
+                refund_all:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Button/_refundAll.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund:
+            blocks:
+                bulk_buttons:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_buttons.html.twig'
+                    priority: 20
+                form:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_form.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.form:
+            blocks:
+                table:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/_table.html.twig'
+                    priority: 30
+                payment_method:
+                    template: '@SyliusRefundPlugin/_paymentMethod.html.twig'
+                    priority: 20
+                footer:
+                    template: '@SyliusRefundPlugin/_footer.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.form.table.header:
+            blocks:
+                item_info:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Header/_itemInfo.html.twig'
+                    priority: 40
+                total:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Header/_total.html.twig'
+                    priority: 30
+                refund_value:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Header/_refundValue.html.twig'
+                    priority: 20
+                blank:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Header/_blank.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.form.table.body:
+            blocks:
+                items:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/_items.html.twig'
+                    priority: 20
+                shipping:
+                    template: '@SyliusRefundPlugin/_shipping.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.table.body.item:
+            blocks:
+                item_info:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Body/Item/_itemInfo.html.twig'
+                    priority: 40
+                total:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Body/Item/_total.html.twig'
+                    priority: 30
+                refund_value:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Body/Item/_refundValue.html.twig'
+                    priority: 20
+                refund_button:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/Form/Table/Body/Item/_refundButton.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.form.payment_method:
+            blocks:
+                navigation:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_paymentMethod.html.twig'
+                    priority: 20
+                refunded_total:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_comment.html.twig'
+                    priority: 10
+
+        sylius_refund.admin.order.refund.form.footer:
+            blocks:
+                navigation:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_navigation.html.twig'
+                    priority: 20
+                refunded_total:
+                    template: '@SyliusRefundPlugin/Order/Admin/Refund/_refundedTotal.html.twig'
+                    priority: 10

--- a/src/Resources/views/Order/Admin/Refund/Button/_clearAll.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Button/_clearAll.html.twig
@@ -1,0 +1,1 @@
+<button data-refund-clear type="button" class="ui button" {{ disableButton }}>{{ 'sylius_refund.ui.clear_refunds'|trans }}</button>

--- a/src/Resources/views/Order/Admin/Refund/Button/_refundAll.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Button/_refundAll.html.twig
@@ -1,0 +1,1 @@
+<button data-refund-all type="button" class="ui button primary" {{ disableButton }}>{{ 'sylius_refund.ui.refund_all'|trans }}</button>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_itemInfo.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_itemInfo.html.twig
@@ -1,0 +1,3 @@
+<td class="single line">
+    {% include '@SyliusAdmin/Product/_info.html.twig' %}
+</td>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_refundButton.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_refundButton.html.twig
@@ -1,0 +1,5 @@
+<td class="aligned collapsing">
+    <button data-refund="{{ unit_refund_left(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT'), unit.total) }}" type="button" class="ui button primary" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %}disabled{% endif %}>
+        {{ 'sylius_refund.ui.refund'|trans }}
+    </button>
+</td>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_refundValue.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_refundValue.html.twig
@@ -1,0 +1,9 @@
+<td class="aligned collapsing partial-refund">
+    {% set inputName = "sylius_refund_units["~unit.id~"][amount]" %}
+    {% set hiddenInputName = "sylius_refund_units["~unit.id~"][partial-id]" %}
+
+    <div class="ui labeled input">
+        <div class="ui label">{{ order.currencyCode|sylius_currency_symbol }}</div>
+        <input data-refund-input type="number" step="0.01" name="{{ inputName }}" {% if not can_unit_be_refunded(unit.id, constant('Sylius\\RefundPlugin\\Model\\RefundType::ORDER_ITEM_UNIT')) %} disabled{% endif %}/>
+    </div>
+</td>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_total.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Body/Item/_total.html.twig
@@ -1,0 +1,3 @@
+<td class="right aligned total">
+    {% include '@SyliusRefundPlugin/_unitTotal.html.twig' %}
+</td>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_blank.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_blank.html.twig
@@ -1,0 +1,1 @@
+<th class="center aligned"></th>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_itemInfo.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_itemInfo.html.twig
@@ -1,0 +1,1 @@
+<th class="wide sylius-table-column-item">{{ 'sylius.ui.order_item_product'|trans }}</th>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_refundValue.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_refundValue.html.twig
@@ -1,0 +1,1 @@
+<th class="center aligned">{{ 'sylius_refund.ui.refund_value'|trans }}</th>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_total.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/Header/_total.html.twig
@@ -1,0 +1,1 @@
+<th class="center aligned sylius-table-column-total">{{ 'sylius.ui.total'|trans }}</th>

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/_items.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/_items.html.twig
@@ -1,0 +1,9 @@
+{% for item in order.items %}
+    {% for unit in item.units %}
+        {% set variant = item.variant %}
+        {% set product = variant.product %}
+        <tr class="unit">
+            {{ sylius_template_event('sylius_refund.admin.order.refund.table.body.item', _context) }}
+        </tr>
+    {% endfor %}
+{% endfor %}

--- a/src/Resources/views/Order/Admin/Refund/Form/Table/_table.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/Form/Table/_table.html.twig
@@ -1,0 +1,10 @@
+<table id="refunds" class="ui compact celled table">
+    <thead>
+    <tr>
+        {{ sylius_template_event('sylius_refund.admin.order.refund.form.table.header', _context) }}
+    </tr>
+    </thead>
+    <tbody>
+    {{ sylius_template_event('sylius_refund.admin.order.refund.form.table.body', _context) }}
+    </tbody>
+</table>

--- a/src/Resources/views/Order/Admin/Refund/_buttons.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_buttons.html.twig
@@ -1,0 +1,6 @@
+<div class="ui right aligned grid">
+    <div class="sixteen wide column">
+        {{ sylius_template_event('sylius_refund.admin.order.refund.buttons', _context) }}
+        <div class="ui hidden divider"></div>
+    </div>
+</div>

--- a/src/Resources/views/Order/Admin/Refund/_comment.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_comment.html.twig
@@ -1,0 +1,6 @@
+<div class="ui form column">
+    <div class="field">
+        <label for="sylius-refund-comment">{{ 'sylius.ui.comment'|trans }}</label>
+        <textarea rows="3" name="sylius_refund_comment" id="sylius-refund-comment"></textarea>
+    </div>
+</div>

--- a/src/Resources/views/Order/Admin/Refund/_form.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_form.html.twig
@@ -1,0 +1,5 @@
+<form action="{{ path('sylius_refund_refund_units', {'orderNumber': app.request.attributes.get('orderNumber')}) }}" method="post">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token(app.request.attributes.get('orderNumber')) }}" />
+    {{ sylius_template_event('sylius_refund.admin.order.refund.form', _context) }}
+    <div class="ui hidden divider"></div>
+</form>

--- a/src/Resources/views/Order/Admin/Refund/_navigation.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_navigation.html.twig
@@ -1,0 +1,10 @@
+<div class="column">
+    <div class="ui buttons">
+        <button id="page-button" class="ui labeled icon primary button" type="submit" {{ disableButton }}>
+            <i class="check icon"></i>{{ 'sylius.ui.refund'|trans }}
+        </button>
+        <a id="back" href="{{ path('sylius_admin_order_show', {'id': order.id}) }}" class="ui button">
+            {{ 'sylius.ui.back'|trans }}
+        </a>
+    </div>
+</div>

--- a/src/Resources/views/Order/Admin/Refund/_paymentMethod.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_paymentMethod.html.twig
@@ -1,0 +1,13 @@
+<div class="ui form column">
+    <div class="field">
+        <label for="payment-methods">{{ 'sylius.ui.payment_method'|trans }}</label>
+        <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown">
+            {% for payment_method in payment_methods %}
+                <option value="{{ payment_method.id }}" {{ (payment_method.code == original_payment_method.code) ? 'selected="selected"' : '' }}>
+                    {{ payment_method.name }}
+                </option>
+            {% endfor %}
+        </select>
+        <small id="original-payment-method">{{ 'sylius.ui.original_payment_method'|trans }}: <strong>{{ original_payment_method }}</strong></small>
+    </div>
+</div>

--- a/src/Resources/views/Order/Admin/Refund/_refundedTotal.html.twig
+++ b/src/Resources/views/Order/Admin/Refund/_refundedTotal.html.twig
@@ -1,0 +1,10 @@
+{% import '@SyliusAdmin/Common/Macro/money.html.twig' as money %}
+
+<div class="column">
+    <div class="ui right aligned basic segment">
+        <h3 id="refunded-total">
+            {{ 'sylius_refund.ui.refunded_total'|trans }}:
+            {{ money.format(order_refunded_total(order.number), order.currencyCode) }}
+        </h3>
+    </div>
+</div>

--- a/src/Resources/views/_footer.html.twig
+++ b/src/Resources/views/_footer.html.twig
@@ -2,16 +2,6 @@
 
 <div class="ui stackable grid">
     <div class="two column row">
-        <div class="column">
-            {% include '@SyliusRefundPlugin/_navigation.html.twig' %}
-        </div>
-        <div class="column">
-            <div class="ui right aligned basic segment">
-                <h3 id="refunded-total">
-                    {{ 'sylius_refund.ui.refunded_total'|trans }}:
-                    {{ money.format(order_refunded_total(order.number), order.currencyCode) }}
-                </h3>
-            </div>
-        </div>
+        {{ sylius_template_event('sylius_refund.admin.order.refund.form.footer', _context) }}
     </div>
 </div>

--- a/src/Resources/views/_paymentMethod.html.twig
+++ b/src/Resources/views/_paymentMethod.html.twig
@@ -5,25 +5,7 @@
 
     <div class="ui stackable grid">
         <div class="two column row">
-            <div class="ui form column">
-                <div class="field">
-                    <label for="payment-methods">{{ 'sylius.ui.payment_method'|trans }}</label>
-                    <select id="payment-methods" name="sylius_refund_payment_method" class="ui fluid selection dropdown">
-                        {% for payment_method in payment_methods %}
-                            <option value="{{ payment_method.id }}" {{ (payment_method.code == original_payment_method.code) ? 'selected="selected"' : '' }}>
-                                {{ payment_method.name }}
-                            </option>
-                        {% endfor %}
-                    </select>
-                    <small id="original-payment-method">{{ 'sylius.ui.original_payment_method'|trans }}: <strong>{{ original_payment_method }}</strong></small>
-                </div>
-            </div>
-            <div class="ui form column">
-                <div class="field">
-                    <label for="sylius-refund-comment">{{ 'sylius.ui.comment'|trans }}</label>
-                    <textarea rows="3" name="sylius_refund_comment" id="sylius-refund-comment"></textarea>
-                </div>
-            </div>
+            {{ sylius_template_event('sylius_refund.admin.order.refund.form.payment_method', _context) }}
         </div>
     </div>
 {% endif %}

--- a/src/Resources/views/orderRefunds.html.twig
+++ b/src/Resources/views/orderRefunds.html.twig
@@ -12,34 +12,7 @@
     <div class="ui stackable grid">
         <div class="sixteen wide column">
             <div class="ui segment">
-                <div class="ui right aligned grid">
-                    <div class="sixteen wide column">
-                        <button data-refund-clear type="button" class="ui button" {{ disableButton }}>{{ 'sylius_refund.ui.clear_refunds'|trans }}</button>
-                        <button data-refund-all type="button" class="ui button primary" {{ disableButton }}>{{ 'sylius_refund.ui.refund_all'|trans }}</button>
-                        <div class="ui hidden divider"></div>
-                    </div>
-                </div>
-                <form action="{{ path('sylius_refund_refund_units', {'orderNumber': app.request.attributes.get('orderNumber')}) }}" method="post">
-                    <input type="hidden" name="_csrf_token" value="{{ csrf_token(app.request.attributes.get('orderNumber')) }}" />
-                    <table id="refunds" class="ui compact celled table">
-                        <thead>
-                            <tr>
-                                <th class="wide sylius-table-column-item">{{ 'sylius.ui.order_item_product'|trans }}</th>
-                                <th class="center aligned sylius-table-column-total">{{ 'sylius.ui.total'|trans }}</th>
-                                <th class="center aligned">{{ 'sylius_refund.ui.refund_value'|trans }}</th>
-                                <th class="center aligned"></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% include '@SyliusRefundPlugin/_items.html.twig' %}
-                            {% include '@SyliusRefundPlugin/_shipping.html.twig' %}
-                        </tbody>
-                    </table>
-
-                    {% include '@SyliusRefundPlugin/_paymentMethod.html.twig' %}
-                    {% include '@SyliusRefundPlugin/_footer.html.twig' %}
-                    <div class="ui hidden divider"></div>
-                </form>
+                {{ sylius_template_event('sylius_refund.admin.order.refund', _context) }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | no

These events were introduced to ease `Plus` installation and to remove redundant templates
