### PR TITLE
[Composer] Require php-http/message-factory package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,10 @@ jobs:
                 run: vendor/bin/ecs check src/ spec/
 
             -
+                name: Lint container
+                run: (cd tests/Application && bin/console lint:container)
+
+            -
                 name: Run PHPStan
                 run: vendor/bin/phpstan analyse -c phpstan.neon src/
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^8.0",
         "knplabs/knp-snappy-bundle": "^1.7",
         "myclabs/php-enum": "^1.7",
+        "php-http/message-factory": "^1.1",
         "sylius/resource-bundle": "^1.6",
         "sylius/sylius": "~1.11.4 || ~1.12.0",
         "symfony/messenger": "^5.4 || ^6.0"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| Related tickets | 

This dependency was provided up to version `1.15.0` by `php-http/message`, but the latest version no longer provides it, although Sylius 1.11 still needs it. It will be possible to drop this dependency once support for Sylius 1.11 will have been removed.
