### PR TITLE
Add German Translations for Sylius Refund Plugin

### DIFF
--- a/src/Resources/translations/flashes.de.yml
+++ b/src/Resources/translations/flashes.de.yml
@@ -1,0 +1,13 @@
+sylius_refund:
+    at_least_one_unit_should_be_selected_to_refund: 'Es muss mindestens eine Einheit ausgewählt werden, um eine Rückerstattung zu beantragen.'
+    error_occurred: 'Unerwarteter Fehler ist aufgetreten.'
+    free_order_should_not_be_refund: 'Eine kostenlose Bestellung kann nicht zurückerstattet werden.'
+    order_should_be_paid: 'Die Bestellung muss bezahlt sein, damit die Einheiten zurückerstattet werden können.'
+    refund_amount_must_be_greater: 'Der Rückerstattungsbetrag muss größer als 0 sein.'
+    refund_amount_must_be_less: 'Sie können nicht mehr Geld zurückerstatten, als der Gesamtbetrag der zurückerstatteten Einheiten beträgt.'
+    refund_units_must_belong_to_order: 'Die zurückerstatteten Einheiten müssen zur Bestellung gehören.'
+    refund_payment_completed: 'Die Rückerstattung wurde erfolgreich abgeschlossen.'
+    resend_credit_memo_failed: 'Das erneute Senden der Gutschrift ist fehlgeschlagen.'
+    resend_credit_memo_success: 'Die ausgewählte Gutschrift wurde erfolgreich erneut gesendet.'
+    unit_refund_exceeded: 'Sie können nicht mehr Geld zurückerstatten, als der Gesamtbetrag der Bestellung beträgt.'
+    units_successfully_refunded: 'Die ausgewählten Bestelleinheiten wurden erfolgreich zurückerstattet.'

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,38 @@
+sylius_refund:
+    ui:
+        buyer: Käufer
+        clear_refunds: Alle zurücksetzen
+        new: Neu
+        completed: Abgeschlossen
+        credit_memo: Gutschrift
+        credit_memos: Gutschriften
+        download: Herunterladen
+        gross_value: Bruttowert
+        issued_at: Ausgestellt am
+        issued_for_order: Ausgestellt für Bestellung
+        issued_from: Ausgestellt von
+        manage_credit_memos: Gutschriften verwalten
+        net_total: Nettogesamt
+        net_value: Nettowert
+        no: Nr.
+        order_number: Bestellnummer
+        partial_refund: Teilweise Rückerstattung
+        refund: Rückerstattung
+        refund_all: Alle zurückerstatten
+        refund_payment_completed: Rückerstattung wurde erfolgreich abgeschlossen
+        refund_payments: Rückzahlungen
+        refund_value: Rückerstattungsbetrag
+        refunded: Rückerstattet
+        refunded_total: Gesamtbetrag erstattet
+        refunds: Rückerstattungen
+        resend: Erneut senden
+        seller: Verkäufer
+        tax_amount: Steuerbetrag
+        tax_rate: Steuerquote %
+        tax_total: Steuer gesamt
+        unit_net_price: Nettopreis pro Einheit
+
+sylius:
+    ui:
+        original_payment_method: Ursprüngliche Zahlungsmethode
+        partially_refunded: Teilweise zurückerstattet


### PR DESCRIPTION
This pull request introduces German translations for various messages in the Sylius Refund Plugin. The translations improve the usability of the plugin for German-speaking users by providing clear and localized messages.

Changes include:
- Added translations for standard messages and flashes, ensuring users receive notifications and prompts in German.

This update aims to enhance the overall user experience for German-speaking customers and maintain consistency with existing localization efforts within the project.
