### PR TITLE
[Admin] Render button for order refund only if refund is possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 /tests/TestApplication/.env.local
 /tests/TestApplication/.env.*.local
+/var/
 
 phpspec.yml
 

--- a/features/refunding_single_order_unit.feature
+++ b/features/refunding_single_order_unit.feature
@@ -47,7 +47,7 @@ Feature: Refunding a single order unit
     @ui
     Scenario: Not being able to refund unit from an order that is unpaid
         When I am viewing the summary of the order "#00000022"
-        Then I should see disabled refunds button
+        Then I should not see refunds button
 
     @application
     Scenario: Not being able to refund unit from an order that is unpaid

--- a/templates/admin/order/content/header/title_block/actions/refunds.html.twig
+++ b/templates/admin/order/content/header/title_block/actions/refunds.html.twig
@@ -1,7 +1,10 @@
 {% set order = hookable_metadata.context.resource %}
-{% set path = path('sylius_refund_order_refunds_list', {'orderNumber': order.number,}) %}
 
-<a class="dropdown-item {% if not can_refund_order(order.number) %}disabled{% endif %}" href="{{ path }}" {{ sylius_test_html_attribute('refunds') }}>
-    {{ ux_icon('tabler:repeat', {'class': 'icon dropdown-item-icon'}) }}
-    {{ 'sylius_refund.ui.refunds'|trans }}
-</a>
+{% if can_refund_order(order.number) %}
+    {% set path = path('sylius_refund_order_refunds_list', {'orderNumber': order.number,}) %}
+
+    <a class="dropdown-item" href="{{ path }}" {{ sylius_test_html_attribute('refunds') }}>
+        {{ ux_icon('tabler:repeat', {'class': 'icon dropdown-item-icon'}) }}
+        {{ 'sylius_refund.ui.refunds'|trans }}
+    </a>
+{% endif %}

--- a/tests/Behat/Context/Ui/ManagingOrdersContext.php
+++ b/tests/Behat/Context/Ui/ManagingOrdersContext.php
@@ -33,9 +33,7 @@ final class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see refunds button
-     */
+    #[Then('I should not see refunds button')]
     public function iShouldNotSeeRefundsButton(): void
     {
         Assert::false($this->showPage->hasRefundsButton());

--- a/tests/Behat/Page/Admin/Order/ShowPage.php
+++ b/tests/Behat/Page/Admin/Order/ShowPage.php
@@ -37,7 +37,7 @@ final class ShowPage extends BaseOrderShowPage implements ShowPageInterface
 
     public function hasRefundsButton(): bool
     {
-        return $this->getDocument()->hasButton('Refunds');
+        return $this->getDocument()->has('css', '[data-test-refunds]');
     }
 
     public function hasDisabledRefundsButton(): bool


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| Related tickets | 

This change disables the entire button instead of only applying the disabled attribute. It makes integration easier with different payment gateways, where refund logic often varies and can depend on the specific gateway implementation.