### PR TITLE
Fix sprintf format for partial price in Refund context

### DIFF
--- a/tests/Behat/Context/Ui/RefundingContext.php
+++ b/tests/Behat/Context/Ui/RefundingContext.php
@@ -113,7 +113,7 @@ final class RefundingContext implements Context
         $this->orderRefundsPage->pickPartOfUnitWithProductToRefund(
             $productName,
             $unitNumber-1,
-            sprintf("%f.2", $partialPrice / 100)
+            sprintf("%.2f", $partialPrice / 100)
         );
 
         $this->orderRefundsPage->choosePaymentMethod($paymentMethod);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| Related tickets | none

While using the behat context from this plugin for this PR : https://github.com/FLUX-SE/SyliusStripePlugin/pull/20
I Discovered an odd bug that should make the CI fail normally.

This is just a quick fix there is other things to fix to make this contexts usable externaly.