### PR TITLE
Cast total to string before setting value in refund inputs

### DIFF
--- a/tests/Behat/Page/Admin/OrderRefundsPage.php
+++ b/tests/Behat/Page/Admin/OrderRefundsPage.php
@@ -44,7 +44,7 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
         /** @var double $total */
         $total -= $refunded;
 
-        $units[$unitNumber]->find('css','td:nth-child(3) input')->setValue($total);
+        $units[$unitNumber]->find('css','td:nth-child(3) input')->setValue((string) $total);
     }
 
     public function pickPartOfUnitWithProductToRefund(string $productName, int $unitNumber, string $amount): void
@@ -71,7 +71,7 @@ final class OrderRefundsPage extends SymfonyPage implements OrderRefundsPageInte
             $total = (double) substr($total, 1) - (double) substr($refunded, 1);
         }
 
-        $orderShipment->find('css','td:nth-child(3) input')->setValue($total);
+        $orderShipment->find('css','td:nth-child(3) input')->setValue((string) $total);
     }
 
     public function pickPartOfOrderShipmentToRefund(string $amount): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| Related tickets | none

Setting a value on an input field requires it to be a string. Without this fix you can end up with this error:

```log
Behat\Testwork\Call\Exception\FatalThrowableError: Type error: Symfony\Component\Panther\DomCrawler\Field\InputFormField::setTextValue():
Argument #1 ($value) must be of type ?string, float given,
called in vendor/symfony/panther/src/DomCrawler/Field/InputFormField.php
on line 29 in vendor/symfony/panther/src/DomCrawler/Field/FormFieldTrait.php:57
Stack trace:
#0 vendor/symfony/panther/src/DomCrawler/Field/InputFormField.php(29): Symfony\Component\Panther\DomCrawler\Field\InputFormField->setTextValue(10.0)
#1 vendor/robertfausk/mink-panther-driver/src/PantherDriver.php(559): Symfony\Component\Panther\DomCrawler\Field\InputFormField->setValue(10.0)
#2 vendor/friends-of-behat/mink/src/Element/NodeElement.php(105): Behat\Mink\Driver\PantherDriver->setValue('((//html/descen...', 10.0)
#3 vendor/sylius/refund-plugin/tests/Behat/Page/Admin/OrderRefundsPage.php(47): Behat\Mink\Element\NodeElement->setValue(10.0)
#4 vendor/sylius/refund-plugin/tests/Behat/Context/Ui/RefundingContext.php(54): 
```