### PR TITLE
Add telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Instead, all security issues must be sent to `security@sylius.com`.
 
 For online communication, we invite you to chat with us and other users on [Sylius Slack](https://sylius.com/slack).
 
+## Telemetry
+
+This plugin includes telemetry that collects anonymous usage data. For more information, see [TELEMETRY_POLICY.md](TELEMETRY_POLICY.md).
+
 ## License
 
 This plugin is released under the [MIT License](LICENSE).

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "myclabs/php-enum": "^1.8",
         "sylius/resource-bundle": "^1.12",
         "sylius/sylius": "^2.0",
+        "sylius/telemetry": "^1.0",
         "symfony/messenger": "^6.4 || ^7.1",
         "php-http/discovery": "^1.20"
     },

--- a/src/SyliusRefundPlugin.php
+++ b/src/SyliusRefundPlugin.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\RefundPlugin;
 
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
+use Sylius\Telemetry\TelemetryCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SyliusRefundPlugin extends Bundle
@@ -23,5 +25,11 @@ final class SyliusRefundPlugin extends Bundle
     public function getPath(): string
     {
         return \dirname(__DIR__);
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(new TelemetryCompilerPass());
     }
 }


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588