### PR TITLE
Add tests/Application/node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /composer.lock
 /node_modules/
+tests/Application/node_modules/
 /var/
 /vendor/
 


### PR DESCRIPTION
Prevents accidental commit of test application node_modules.