### PR TITLE
[Maintenance][CI] Restore knp_snappy binary wiring in test app config

### DIFF
--- a/tests/TestApplication/config/config.yaml
+++ b/tests/TestApplication/config/config.yaml
@@ -5,3 +5,9 @@ imports:
 twig:
     paths:
         '%kernel.project_dir%/../../../tests/TestApplication/templates': ~
+
+knp_snappy:
+    pdf:
+        enabled: true
+        binary: '%env(resolve:WKHTMLTOPDF_PATH)%'
+        options: []


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| Related tickets | 
